### PR TITLE
Fix(action): Remove empty expression syntax

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -395,6 +395,12 @@ runs:
         INPUT_INCLUDE_PROJECTS: ${{ inputs.include-projects }}
         INPUT_EXCLUDE_PROJECTS: ${{ inputs.exclude-projects }}
       run: |
+        # WARNING: Do NOT use literal empty expression syntax (dollar
+        # brace-brace with nothing inside) anywhere in this run block,
+        # including in comments. The GitHub Actions template engine
+        # parses ALL expression patterns in run blocks and rejects
+        # empty ones with "An expression was expected".
+
         # Use action-managed SSH agent socket if it exists; otherwise,
         # fall back to any existing SSH_AUTH_SOCK on the runner so that
         # SSH-based clones using the runner's default agent/keys still work.
@@ -569,8 +575,9 @@ runs:
         fi
 
         # Add include-projects options (supports multiple)
-        # Use env var to avoid shell injection from ${{ }} in
-        # command substitutions; normalize commas to spaces.
+        # Use env var to avoid shell injection from expression
+        # interpolation in command substitutions; normalize
+        # commas to spaces.
         if [ -n "$INPUT_INCLUDE_PROJECTS" ]; then
           read -ra PROJECTS \
             <<< "$(printf '%s' "$INPUT_INCLUDE_PROJECTS" | tr ',' ' ')"
@@ -582,8 +589,9 @@ runs:
         fi
 
         # Add exclude-projects options (supports multiple)
-        # Use env var to avoid shell injection from ${{ }} in
-        # command substitutions; normalize commas to spaces.
+        # Use env var to avoid shell injection from expression
+        # interpolation in command substitutions; normalize
+        # commas to spaces.
         if [ -n "$INPUT_EXCLUDE_PROJECTS" ]; then
           read -ra EXCLUDES \
             <<< "$(printf '%s' "$INPUT_EXCLUDE_PROJECTS" | tr ',' ' ')"

--- a/tests/test_action_cli_alignment.py
+++ b/tests/test_action_cli_alignment.py
@@ -441,3 +441,74 @@ class TestActionInputToCLIMapping:
         assert "path" not in cli_option_names, (
             "CLI should NOT have standalone '--path' option"
         )
+
+
+class TestNoEmptyExpressions:
+    """Detect empty or malformed GitHub Actions expression patterns.
+
+    The Actions template engine parses ALL ${{ }} patterns in run
+    blocks — including inside shell comments.  An empty expression
+    like ``${{ }}`` causes the runner to reject the manifest with
+    "An expression was expected".
+
+    See: https://github.com/lfreleng-actions/project-reporting-tool/
+         actions/runs/24069756050
+    """
+
+    EXPRESSION_RE: ClassVar[re.Pattern[str]] = re.compile(r"\$\{\{(.*?)\}\}", re.DOTALL)
+
+    def _collect_run_blocks(self, action_yaml: dict[str, Any]) -> list[tuple[str, str]]:
+        """Extract all run blocks from the action manifest.
+
+        Returns:
+            List of (step_name, run_content) tuples.
+        """
+        blocks: list[tuple[str, str]] = []
+        steps = action_yaml.get("runs", {}).get("steps", [])
+        for step in steps:
+            if "run" in step:
+                name = step.get("name", step.get("id", "unnamed"))
+                blocks.append((name, step["run"]))
+        return blocks
+
+    def test_no_empty_expressions_in_run_blocks(
+        self, action_yaml: dict[str, Any]
+    ) -> None:
+        """Every ${{ }} expression must have non-empty content."""
+        violations: list[str] = []
+        for step_name, script in self._collect_run_blocks(action_yaml):
+            for match in self.EXPRESSION_RE.finditer(script):
+                body = match.group(1).strip()
+                if not body:
+                    # Show surrounding context for easier debugging
+                    start = max(0, match.start() - 30)
+                    end = min(len(script), match.end() + 30)
+                    context = script[start:end].replace("\n", "\\n")
+                    violations.append(
+                        f"Step '{step_name}': empty expression near: ...{context}..."
+                    )
+        assert not violations, (
+            "Found empty ${{{{ }}}} expression(s) in action.yaml run "
+            "blocks. The GitHub Actions template engine rejects these "
+            "with 'An expression was expected':\n"
+            + "\n".join(f"  - {v}" for v in violations)
+        )
+
+    def test_no_unclosed_expressions_in_run_blocks(
+        self, action_yaml: dict[str, Any]
+    ) -> None:
+        """Every ${{ must have a matching }}."""
+        unclosed_re = re.compile(r"\$\{\{(?:(?!\}\}).)*$", re.DOTALL)
+        violations: list[str] = []
+        for step_name, script in self._collect_run_blocks(action_yaml):
+            for match in unclosed_re.finditer(script):
+                start = max(0, match.start() - 20)
+                end = min(len(script), match.end() + 20)
+                context = script[start:end].replace("\n", "\\n")
+                violations.append(
+                    f"Step '{step_name}': unclosed expression near: ...{context}..."
+                )
+        assert not violations, (
+            "Found unclosed ${{{{ expression(s) in action.yaml run "
+            "blocks:\n" + "\n".join(f"  - {v}" for v in violations)
+        )


### PR DESCRIPTION
## Urgent Fix: Remove empty expression syntax from action.yaml

Two shell comments in the **Clone repositories** step contained literal
empty expression text that the GitHub Actions template engine evaluates.
The runner parses all expression patterns in `run` blocks, including
inside comments, and rejects empty ones with:

> "An expression was expected"

### Changes

- Reword the comments to describe the intent without using the literal
  expression syntax
- Add a warning comment at the top of the run block
- Add a regression test that scans all run blocks for empty or unclosed
  expression patterns

Cherry-picked from commit `b956243683bb864e11fb4395d711989edc6b07fa`
(PR #127) onto a dedicated branch from `main`.