### PR TITLE
Fix(coverage): Use package name in coverage source list

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -262,7 +262,7 @@ asyncio_default_fixture_loop_scope = "function"
 
 # Coverage configuration
 [tool.coverage.run]
-source = ["src"]
+source = ["gerrit_clone"]
 branch = true
 omit = [
     "*/tests/*",


### PR DESCRIPTION
## Summary

`source = ["src"]` in `[tool.coverage.run]` is a filesystem path.
coverage.py treats entries containing a path separator (or that resolve
to a directory) as **path filters**, not package names. Under
`lfreleng-actions/python-test-action` v1.1.x — which installs the
package **non-editably** into `.venv/lib/pythonX.Y/site-packages/` —
that filter never matches the installed location and coverage reports
0% with a `No data was collected` warning.

Use the import name `gerrit_clone` instead. coverage.py instruments
the package wherever it is imported from (editable or installed),
which is the robust configuration.

## Why this is a preventive change

This project currently still reports correct coverage on
`python-test-action` v1.0.x because `[tool.pytest.ini_options].addopts`
includes `--cov=gerrit_clone`, which overrides the path-based source
list at runtime. The fix removes that latent failure mode so the
project remains correctly measured if `addopts` changes or the
action's flag handling evolves again.

## Related fixes

Same root cause, already addressed in sibling projects:

- lfreleng-actions/markdown-table-fixer#129
- lfreleng-actions/gha-workflow-linter#196

## Change

```diff
 [tool.coverage.run]
-source = ["src"]
+source = ["gerrit_clone"]
```

One line; no other changes.