### PR TITLE
Build(deps): Add uv exclude-newer cooldown

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -346,3 +346,9 @@ dev = [
     "pytest-mock>=3.15.1",
     "types-pyyaml>=6.0.12.20250915",
 ]
+
+[tool.uv]
+# Supply-chain cooldown: do not resolve anything published in the last
+# 7 days (rolling window; uv records it as a relative span in uv.lock).
+# Requires uv >= 0.9.17 for the relative-duration ("7 days") form.
+exclude-newer = "7 days"

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.11, <3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P7D"
+
 [[package]]
 name = "annotated-doc"
 version = "0.0.4"


### PR DESCRIPTION
Adds a `[tool.uv] exclude-newer = "7 days"` resolver cooldown and refreshes `uv.lock`.

**Why:** uv refuses to lock any dependency published within the last 7 days, giving the community time to catch a compromised release before it enters the lockfile. Complements the existing Dependabot `uv` cooldown (which only gates update PRs, not local or agent `uv lock` resolutions).

**Notes:**
- Re-locking may roll a recently published dependency back to the newest release older than the 7-day window (visible in the `uv.lock` diff); it returns on a later lock once it ages past the window. This repository locked cleanly with no version changes.
- uv 0.11.x records the cooldown as a relative span (`exclude-newer-span = "P7D"`); the lockfile carries a backwards-compatible no-op placeholder so older uv in CI still reads it.
- Requires uv >= 0.9.17 for the relative-duration form.
- Part of an organisation-wide rollout across uv-managed repositories.