### PR TITLE
Fix: Prevent SSH discovery on HTTPS port

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -171,9 +171,12 @@ inputs:
     required: false
     default: "true"
   discovery-method:
-    description: "Discovery method: ssh, http, both, or github_api"
+    description: >-
+      Discovery method: ssh, http, both, or github_api. Leave empty to
+      derive from the clone protocol (http with use-https, otherwise ssh;
+      github_api for GitHub sources).
     required: false
-    default: "ssh"
+    default: ""
   keep-remote-protocol:
     description: "Preserve original protocol for remote (default: SSH)"
     required: false
@@ -606,11 +609,9 @@ runs:
           fi
         fi
 
-        # Discovery method (auto-select http for HTTPS)
-        if [ "${INPUT_USE_HTTPS}" = "true" ] && \
-          [ "${INPUT_DISCOVERY_METHOD}" = "ssh" ]; then
-          cmd+=(--discovery-method http)
-        elif [ "${INPUT_DISCOVERY_METHOD}" != "ssh" ]; then
+        # Discovery method (when empty, the CLI derives it from the clone
+        # protocol, keeping discovery and cloning consistent).
+        if [ -n "${INPUT_DISCOVERY_METHOD}" ]; then
           cmd+=(--discovery-method \
             "${INPUT_DISCOVERY_METHOD}")
         fi

--- a/src/gerrit_clone/cli.py
+++ b/src/gerrit_clone/cli.py
@@ -169,8 +169,9 @@ def clone(
         "--port",
         "-p",
         help=(
-            "Gerrit SSH/HTTP port (default: 29418 for SSH, 443 for HTTPS). "
-            "Note: Only used for Gerrit sources; ignored for GitHub sources."
+            "Gerrit SSH port (default: 29418). HTTPS discovery and cloning use "
+            "the base URL, not this port. Only used for Gerrit sources; "
+            "ignored for GitHub sources."
         ),
         envvar="GERRIT_PORT",
         min=1,
@@ -244,10 +245,14 @@ def clone(
         help="Enable verbose SSH (-vvv) for troubleshooting authentication (single or few projects).",
         envvar="GERRIT_SSH_DEBUG",
     ),
-    discovery_method: str = typer.Option(
-        "ssh",
+    discovery_method: str | None = typer.Option(
+        None,
         "--discovery-method",
-        help="Method for discovering projects: ssh (default for Gerrit), http (REST API), both (union of both), or github_api (for GitHub)",
+        help=(
+            "Method for discovering projects: ssh, http (REST API), both "
+            "(union of both), or github_api. Default: derived from the clone "
+            "protocol (http with --https, ssh otherwise; github_api for GitHub)"
+        ),
         envvar="GERRIT_DISCOVERY_METHOD",
     ),
     allow_nested_git: bool = typer.Option(
@@ -693,30 +698,42 @@ def clone(
             except Exception:
                 file_logger.warning("Version information not available")
 
-        # Parse discovery method and adjust for source type
-        try:
-            discovery_method_enum = DiscoveryMethod(discovery_method.lower())
-        except ValueError:
+        # Parse discovery method (None means "derive in Config from source
+        # type and clone protocol"). Only validate/convert when explicitly set.
+        discovery_method_enum: DiscoveryMethod | None = None
+        if discovery_method and discovery_method.strip():
             console = Console()
-            console.print(
-                Panel(
-                    Text(
-                        f"Invalid discovery method '{discovery_method}'\nMust be one of: ssh, http, both, github_api",
-                        style="bold red",
-                    ),
-                    title="Configuration Error",
-                    border_style="red",
+            try:
+                discovery_method_enum = DiscoveryMethod(
+                    discovery_method.strip().lower()
                 )
-            )
-            raise typer.Exit(ExitCode.CONFIGURATION_ERROR) from None
-
-        # Auto-adjust discovery method for GitHub
-        if detected_source_type == SourceType.GITHUB and discovery_method_enum not in [DiscoveryMethod.GITHUB_API, DiscoveryMethod.HTTP]:
-            discovery_method_enum = DiscoveryMethod.GITHUB_API
-            if not quiet:
+            except ValueError:
                 console.print(
-                    "[cyan]ℹ[/cyan] Using GitHub API discovery for GitHub source"  # noqa: RUF001
+                    Panel(
+                        Text(
+                            f"Invalid discovery method '{discovery_method}'\nMust be one of: ssh, http, both, github_api",
+                            style="bold red",
+                        ),
+                        title="Configuration Error",
+                        border_style="red",
+                    )
                 )
+                raise typer.Exit(ExitCode.CONFIGURATION_ERROR) from None
+
+            # Auto-adjust explicit discovery method for GitHub
+            if (
+                detected_source_type == SourceType.GITHUB
+                and discovery_method_enum
+                not in [
+                    DiscoveryMethod.GITHUB_API,
+                    DiscoveryMethod.HTTP,
+                ]
+            ):
+                discovery_method_enum = DiscoveryMethod.GITHUB_API
+                if not quiet:
+                    console.print(
+                        "[cyan]ℹ[/cyan] Using GitHub API discovery for GitHub source"  # noqa: RUF001
+                    )
 
         # Load and validate configuration
         try:
@@ -940,9 +957,10 @@ def _show_startup_banner(console: Console, config: Any) -> None:
     lines.append(f"Git Mirror: [cyan]{config.mirror}[/cyan]")
 
     # Add common options
+    discovery = getattr(config, "discovery_method", None) or DiscoveryMethod.SSH
     lines.extend(
         [
-            f"Discovery Method: [cyan]{str(getattr(config, 'discovery_method', DiscoveryMethod.SSH).value).upper()}[/cyan]",
+            f"Discovery Method: [cyan]{discovery.value.upper()}[/cyan]",
             f"Skip Archived: [cyan]{config.skip_archived}[/cyan]",
         ]
     )
@@ -1442,10 +1460,14 @@ def mirror(
         help="Skip archived/read-only repositories",
         envvar="GERRIT_SKIP_ARCHIVED",
     ),
-    discovery_method: str = typer.Option(
-        "ssh",
+    discovery_method: str | None = typer.Option(
+        None,
         "--discovery-method",
-        help="Method for discovering projects: ssh (default), http (REST API only), or both (union of both methods with SSH metadata preferred)",
+        help=(
+            "Method for discovering projects: ssh, http (REST API only), or "
+            "both (union, SSH metadata preferred). Default: derived from the "
+            "clone protocol (http with --https, ssh otherwise)"
+        ),
         envvar="GERRIT_DISCOVERY_METHOD",
     ),
     use_https: bool = typer.Option(
@@ -1744,21 +1766,24 @@ def mirror(
         # Build Gerrit configuration
         from gerrit_clone.models import Config  # noqa: PLC0415
 
-        # Validate discovery method
-        try:
-            discovery_enum = DiscoveryMethod(discovery_method.lower())
-        except ValueError:
-            console.print(
-                Panel(
-                    Text(
-                        f"Invalid discovery method '{discovery_method}'\nMust be one of: ssh, http, both",
-                        style="bold red",
-                    ),
-                    title="Configuration Error",
-                    border_style="red",
+        # Validate discovery method (None means "derive in Config from the
+        # clone protocol"). Only validate/convert when explicitly set.
+        discovery_enum: DiscoveryMethod | None = None
+        if discovery_method and discovery_method.strip():
+            try:
+                discovery_enum = DiscoveryMethod(discovery_method.strip().lower())
+            except ValueError:
+                console.print(
+                    Panel(
+                        Text(
+                            f"Invalid discovery method '{discovery_method}'\nMust be one of: ssh, http, both",
+                            style="bold red",
+                        ),
+                        title="Configuration Error",
+                        border_style="red",
+                    )
                 )
-            )
-            raise typer.Exit(ExitCode.CONFIGURATION_ERROR) from None
+                raise typer.Exit(ExitCode.CONFIGURATION_ERROR) from None
 
         config = Config(
             host=server,
@@ -1852,8 +1877,12 @@ def mirror(
 
         # Show summary
         if not quiet:
+            resolved_discovery = config.discovery_method
+            discovery_label = (
+                resolved_discovery.value.upper() if resolved_discovery else "SSH"
+            )
             console.print("[bold]Mirror Summary[/bold]")
-            console.print(f"  Discovery Method: [cyan]{discovery_enum.value.upper()}[/cyan]")
+            console.print(f"  Discovery Method: [cyan]{discovery_label}[/cyan]")
             console.print(f"  Clone Protocol: [cyan]{'HTTPS' if use_https else 'SSH'}[/cyan]")
             console.print(f"  Skip Archived: [cyan]{skip_archived}[/cyan]")
             console.print(f"  Total: {batch_result.total_count}")

--- a/src/gerrit_clone/cli.py
+++ b/src/gerrit_clone/cli.py
@@ -702,7 +702,6 @@ def clone(
         # type and clone protocol"). Only validate/convert when explicitly set.
         discovery_method_enum: DiscoveryMethod | None = None
         if discovery_method and discovery_method.strip():
-            console = Console()
             try:
                 discovery_method_enum = DiscoveryMethod(
                     discovery_method.strip().lower()
@@ -1773,6 +1772,23 @@ def mirror(
             try:
                 discovery_enum = DiscoveryMethod(discovery_method.strip().lower())
             except ValueError:
+                console.print(
+                    Panel(
+                        Text(
+                            f"Invalid discovery method '{discovery_method}'\nMust be one of: ssh, http, both",
+                            style="bold red",
+                        ),
+                        title="Configuration Error",
+                        border_style="red",
+                    )
+                )
+                raise typer.Exit(ExitCode.CONFIGURATION_ERROR) from None
+
+            # Mirror targets Gerrit only; github_api is a valid enum value but
+            # not a valid Gerrit discovery method. Reject it here so the user
+            # gets a clear configuration error rather than an unexpected error
+            # raised later by Config.
+            if discovery_enum == DiscoveryMethod.GITHUB_API:
                 console.print(
                     Panel(
                         Text(

--- a/src/gerrit_clone/config.py
+++ b/src/gerrit_clone/config.py
@@ -38,7 +38,7 @@ class ConfigManager:
         ssh_identity_file: str | Path | None = None,
         path: str | Path | None = None,
         skip_archived: bool | None = None,
-        discovery_method: str | None = None,
+        discovery_method: str | DiscoveryMethod | None = None,
         allow_nested_git: bool | None = None,
         nested_protection: bool | None = None,
         move_conflicting: bool | None = None,
@@ -376,16 +376,23 @@ class ConfigManager:
         if "ssh_identity_file" in config_dict:
             config_dict["ssh_identity_file"] = Path(config_dict["ssh_identity_file"])
 
-        # Handle discovery_method conversion
+        # Handle discovery_method conversion. An empty or whitespace value is
+        # treated as unset so Config can derive it from the source type and
+        # clone protocol; drop it here rather than failing validation.
         if "discovery_method" in config_dict:
             dm = config_dict["discovery_method"]
             if isinstance(dm, str):
-                try:
-                    config_dict["discovery_method"] = DiscoveryMethod(dm.lower())
-                except ValueError as err:
-                    raise ConfigurationError(
-                        f"Invalid discovery_method '{dm}'. Must be one of: ssh, http, both"
-                    ) from err
+                if dm.strip():
+                    try:
+                        config_dict["discovery_method"] = DiscoveryMethod(
+                            dm.strip().lower()
+                        )
+                    except ValueError as err:
+                        raise ConfigurationError(
+                            f"Invalid discovery_method '{dm}'. Must be one of: ssh, http, both"
+                        ) from err
+                else:
+                    config_dict.pop("discovery_method")
 
         # Handle source_type conversion
         if "source_type" in config_dict:
@@ -398,9 +405,8 @@ class ConfigManager:
                         f"Invalid source_type '{st}'. Must be one of: gerrit, github"
                     ) from err
 
-        # Smart port defaulting based on protocol and source type
+        # Source-type-aware port and path defaulting
         source_type = config_dict.get("source_type", SourceType.GERRIT)
-        use_https = config_dict.get("use_https", False)
 
         # Auto-adjust path to include server/org structure when using default (current directory)
         # This prevents naming conflicts when multiple clone operations run in the same directory
@@ -425,15 +431,14 @@ class ConfigManager:
 
         # For GitHub sources, port should always be None (not used)
         if source_type == SourceType.GITHUB:
-            if "port" in config_dict:
-                # User explicitly set port for GitHub - remove it
-                config_dict.pop("port")
+            # User may have set port for GitHub - remove it (not meaningful)
+            config_dict.pop("port", None)
         elif "port" not in config_dict:
-            # No port specified, use protocol-appropriate default
-            config_dict["port"] = 443 if use_https else 29418
-        elif config_dict["port"] == 29418 and use_https:
-            # SSH port specified but using HTTPS, switch to HTTPS port
-            config_dict["port"] = 443
+            # Default to the Gerrit SSH port. ``port`` is the SSH port only:
+            # HTTPS discovery and cloning use ``base_url``, never this port, so
+            # it is intentionally left unchanged when use_https is set. This
+            # prevents SSH discovery from ever targeting the HTTPS port (443).
+            config_dict["port"] = 29418
 
         # Coerce string include/exclude_projects to single-element lists
         # so Config.__post_init__ can safely iterate and normalize them.

--- a/src/gerrit_clone/config.py
+++ b/src/gerrit_clone/config.py
@@ -389,7 +389,7 @@ class ConfigManager:
                         )
                     except ValueError as err:
                         raise ConfigurationError(
-                            f"Invalid discovery_method '{dm}'. Must be one of: ssh, http, both"
+                            f"Invalid discovery_method '{dm}'. Must be one of: ssh, http, both, github_api"
                         ) from err
                 else:
                     config_dict.pop("discovery_method")

--- a/src/gerrit_clone/models.py
+++ b/src/gerrit_clone/models.py
@@ -331,8 +331,8 @@ class Config:
 
         # Resolve discovery method as a single source of truth for protocol
         # selection. ``port`` is the SSH port only; HTTPS discovery/cloning use
-        # ``base_url``, so SSH-based discovery cannot work in HTTPS mode (no SSH
-        # credentials are configured and the SSH port is not exposed over HTTPS).
+        # ``base_url``. This tool treats SSH-based discovery as incompatible
+        # with HTTPS clone mode (regardless of whether SSH credentials exist).
         self._resolve_discovery_method()
 
         if self.threads is not None and self.threads < 1:
@@ -437,16 +437,20 @@ class Config:
         SSH discovery against the HTTPS port).
         """
         if self.source_type == SourceType.GITHUB:
-            # GitHub only supports API/HTTP discovery; coerce anything else
-            # (including the unset default) to the GitHub API.
-            if self.discovery_method not in (
-                DiscoveryMethod.GITHUB_API,
-                DiscoveryMethod.HTTP,
-            ):
-                self.discovery_method = DiscoveryMethod.GITHUB_API
+            # GitHub discovery always uses the GitHub API path, regardless of
+            # the requested method. Normalize to GITHUB_API so the resolved
+            # value is unambiguous (HTTP would be misleading here).
+            self.discovery_method = DiscoveryMethod.GITHUB_API
             return
 
-        # Gerrit source
+        # Gerrit source: GitHub API discovery is meaningless and would route
+        # to the GitHub backend, failing in confusing ways. Reject it early.
+        if self.discovery_method == DiscoveryMethod.GITHUB_API:
+            raise ValueError(
+                "discovery_method='github_api' is only valid for GitHub "
+                "sources, not Gerrit. Use 'ssh', 'http', or 'both'."
+            )
+
         if self.use_https:
             if self.discovery_method is None:
                 # HTTPS cloning pairs with HTTP REST discovery.
@@ -458,8 +462,8 @@ class Config:
                 raise ValueError(
                     "use_https requires HTTP-based project discovery, but "
                     f"discovery_method='{self.discovery_method.value}' needs "
-                    "SSH. HTTPS mode configures no SSH credentials and does not "
-                    "expose the SSH port. Use discovery_method='http' (the "
+                    "SSH. SSH-based discovery is incompatible with HTTPS clone "
+                    "mode in this tool. Use discovery_method='http' (the "
                     "default with HTTPS) or clone over SSH instead."
                 )
         elif self.discovery_method is None:

--- a/src/gerrit_clone/models.py
+++ b/src/gerrit_clone/models.py
@@ -250,7 +250,11 @@ class Config:
 
     # Source type and discovery settings
     source_type: SourceType = SourceType.GERRIT
-    discovery_method: DiscoveryMethod = DiscoveryMethod.SSH
+    # ``None`` means "derive from source type and clone protocol" (resolved in
+    # __post_init__). This keeps discovery and clone protocol consistent and
+    # makes contradictory combinations (e.g. SSH discovery with HTTPS cloning)
+    # impossible to reach silently.
+    discovery_method: DiscoveryMethod | None = None
 
     # GitHub-specific settings
     github_token: str | None = None
@@ -325,6 +329,11 @@ class Config:
             if self.port <= 0 or self.port > 65535:
                 raise ValueError("port must be between 1 and 65535")
 
+        # Resolve discovery method as a single source of truth for protocol
+        # selection. ``port`` is the SSH port only; HTTPS discovery/cloning use
+        # ``base_url``, so SSH-based discovery cannot work in HTTPS mode (no SSH
+        # credentials are configured and the SSH port is not exposed over HTTPS).
+        self._resolve_discovery_method()
 
         if self.threads is not None and self.threads < 1:
             raise ValueError("threads must be at least 1")
@@ -417,6 +426,45 @@ class Config:
                 "Set GERRIT_CLONE_TOKEN, GITHUB_TOKEN, or use "
                 "--github-token when needed."
             )
+
+    def _resolve_discovery_method(self) -> None:
+        """Resolve and validate the project discovery method.
+
+        ``discovery_method`` may be ``None`` to request derivation from the
+        source type and clone protocol. This keeps discovery consistent with
+        cloning and fast-fails on contradictory combinations instead of
+        producing an obscure runtime connection error (for example, attempting
+        SSH discovery against the HTTPS port).
+        """
+        if self.source_type == SourceType.GITHUB:
+            # GitHub only supports API/HTTP discovery; coerce anything else
+            # (including the unset default) to the GitHub API.
+            if self.discovery_method not in (
+                DiscoveryMethod.GITHUB_API,
+                DiscoveryMethod.HTTP,
+            ):
+                self.discovery_method = DiscoveryMethod.GITHUB_API
+            return
+
+        # Gerrit source
+        if self.use_https:
+            if self.discovery_method is None:
+                # HTTPS cloning pairs with HTTP REST discovery.
+                self.discovery_method = DiscoveryMethod.HTTP
+            elif self.discovery_method in (
+                DiscoveryMethod.SSH,
+                DiscoveryMethod.BOTH,
+            ):
+                raise ValueError(
+                    "use_https requires HTTP-based project discovery, but "
+                    f"discovery_method='{self.discovery_method.value}' needs "
+                    "SSH. HTTPS mode configures no SSH credentials and does not "
+                    "expose the SSH port. Use discovery_method='http' (the "
+                    "default with HTTPS) or clone over SSH instead."
+                )
+        elif self.discovery_method is None:
+            # SSH cloning pairs with SSH discovery by default.
+            self.discovery_method = DiscoveryMethod.SSH
 
     @property
     def effective_threads(self) -> int:
@@ -684,7 +732,11 @@ class BatchResult:
                 "use_gh_cli": self.config.use_gh_cli,
                 "depth": self.config.depth,
                 "branch": self.config.branch,
-                "discovery_method": self.config.discovery_method.value,
+                "discovery_method": (
+                    self.config.discovery_method.value
+                    if self.config.discovery_method
+                    else None
+                ),
             },
             "total": self.total_count,
             "succeeded": self.success_count,

--- a/tests/test_cli_netrc_options.py
+++ b/tests/test_cli_netrc_options.py
@@ -27,6 +27,7 @@ import pytest
 from typer.testing import CliRunner
 
 from gerrit_clone.cli import app
+from gerrit_clone.error_codes import ExitCode
 from gerrit_clone.netrc import CredentialSource, GerritCredentials
 
 
@@ -442,3 +443,37 @@ class TestHelpOutput:
         assert "--http-password" in output
         assert "--no-netrc" in output
         assert "--netrc-file" in output
+
+
+class TestMirrorDiscoveryMethodValidation:
+    """Test discovery-method validation for the Gerrit-only mirror command."""
+
+    def test_mirror_rejects_github_api_discovery(self, runner):
+        """mirror rejects github_api with a clear CONFIGURATION_ERROR.
+
+        ``github_api`` is a valid ``DiscoveryMethod`` enum value, but it is
+        only meaningful for GitHub sources. Mirror targets Gerrit only, so it
+        must surface a configuration error rather than letting ``Config``
+        raise an unexpected error later.
+
+        A token and an explicit org are supplied so the command reaches the
+        discovery-method validation without requiring network access or a
+        real ``GITHUB_TOKEN`` (the GitHub client only checks a token is
+        present at construction, and ``--org`` avoids the org-lookup call).
+        """
+        result = runner.invoke(
+            app,
+            [
+                "mirror",
+                "--server",
+                "gerrit.example.org",
+                "--org",
+                "example-org",
+                "--github-token",
+                "fake-token",
+                "--discovery-method",
+                "github_api",
+            ],
+        )
+        assert result.exit_code == ExitCode.CONFIGURATION_ERROR
+        assert "Configuration Error" in strip_ansi(result.output)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,7 +15,7 @@ import pytest
 import yaml
 
 from gerrit_clone.config import ConfigManager, ConfigurationError, load_config
-from gerrit_clone.models import Config, SourceType
+from gerrit_clone.models import Config, DiscoveryMethod, SourceType
 
 
 class TestConfigManager:
@@ -396,6 +396,48 @@ class TestLoadConfigFunction:
         assert config.host == "test.gerrit.org"
         assert config.port == 2222
         assert config.threads == 4
+
+
+class TestProtocolDiscoveryConsistency:
+    """Test that the loader keeps clone protocol and discovery consistent.
+
+    Regression coverage for the bug where ``use_https`` forced the port to 443
+    while discovery defaulted to SSH, producing an SSH connection against the
+    HTTPS port.
+    """
+
+    def test_https_keeps_ssh_port_and_derives_http_discovery(self):
+        """use_https must not mutate the SSH port and derives HTTP discovery."""
+        config = load_config(host="gerrit.example.org", use_https=True)
+        assert config.port == 29418
+        assert config.discovery_method == DiscoveryMethod.HTTP
+
+    def test_https_with_explicit_ssh_discovery_fails_fast(self):
+        """Explicit SSH discovery with HTTPS raises a configuration error."""
+        with pytest.raises(ConfigurationError, match="use_https requires HTTP-based"):
+            load_config(
+                host="gerrit.example.org",
+                use_https=True,
+                discovery_method="ssh",
+            )
+
+    def test_https_with_explicit_both_discovery_fails_fast(self):
+        """Explicit 'both' discovery with HTTPS raises a configuration error."""
+        with pytest.raises(ConfigurationError, match="use_https requires HTTP-based"):
+            load_config(
+                host="gerrit.example.org",
+                use_https=True,
+                discovery_method="both",
+            )
+
+    def test_empty_discovery_method_is_derived(self):
+        """An empty discovery_method string is treated as unset and derived."""
+        config = load_config(
+            host="gerrit.example.org",
+            use_https=True,
+            discovery_method="",
+        )
+        assert config.discovery_method == DiscoveryMethod.HTTP
 
 
 class TestPathAutoAdjustment:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -355,6 +355,24 @@ class TestDiscoveryMethodResolution:
         )
         assert config.discovery_method == DiscoveryMethod.GITHUB_API
 
+    def test_github_normalizes_http_discovery_to_api(self):
+        """GitHub normalizes HTTP discovery to github_api (no ambiguity)."""
+        config = Config(
+            host="github.com",
+            source_type=SourceType.GITHUB,
+            github_token="x",
+            discovery_method=DiscoveryMethod.HTTP,
+        )
+        assert config.discovery_method == DiscoveryMethod.GITHUB_API
+
+    def test_gerrit_rejects_github_api_discovery(self):
+        """Gerrit sources reject github_api discovery to avoid mis-routing."""
+        with pytest.raises(ValueError, match="only valid for GitHub"):
+            Config(
+                host="gerrit.example.org",
+                discovery_method=DiscoveryMethod.GITHUB_API,
+            )
+
 
 class TestCloneResult:
     """Test CloneResult dataclass."""

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,6 +15,7 @@ from gerrit_clone.models import (
     CloneResult,
     CloneStatus,
     Config,
+    DiscoveryMethod,
     Project,
     ProjectState,
     RetryPolicy,
@@ -275,6 +276,84 @@ class TestConfig:
             config.git_ssh_command
             == "ssh -o BatchMode=yes -o ConnectTimeout=10 -o ServerAliveInterval=5 -o ServerAliveCountMax=3 -o ConnectionAttempts=2 -o StrictHostKeyChecking=accept-new"
         )
+
+
+class TestDiscoveryMethodResolution:
+    """Test discovery method derivation and protocol consistency.
+
+    ``port`` is the SSH port only; HTTPS discovery/cloning use ``base_url``.
+    These tests guard against the regression where HTTPS mode silently ran
+    SSH discovery against the HTTPS port (443).
+    """
+
+    def test_gerrit_ssh_defaults_to_ssh_discovery(self):
+        """Gerrit over SSH derives SSH discovery on the SSH port."""
+        config = Config(host="gerrit.example.org")
+        assert config.use_https is False
+        assert config.discovery_method == DiscoveryMethod.SSH
+        assert config.port == 29418
+
+    def test_gerrit_https_derives_http_discovery(self):
+        """Gerrit over HTTPS derives HTTP discovery and keeps the SSH port."""
+        config = Config(host="gerrit.example.org", use_https=True)
+        assert config.discovery_method == DiscoveryMethod.HTTP
+        # Port is the SSH port and must never become 443 (HTTPS uses base_url)
+        assert config.port == 29418
+
+    def test_https_with_explicit_http_is_allowed(self):
+        """HTTPS cloning paired with explicit HTTP discovery is valid."""
+        config = Config(
+            host="gerrit.example.org",
+            use_https=True,
+            discovery_method=DiscoveryMethod.HTTP,
+        )
+        assert config.discovery_method == DiscoveryMethod.HTTP
+
+    def test_https_with_explicit_ssh_discovery_fails_fast(self):
+        """HTTPS cloning with SSH discovery is contradictory and must raise."""
+        with pytest.raises(ValueError, match="use_https requires HTTP-based"):
+            Config(
+                host="gerrit.example.org",
+                use_https=True,
+                discovery_method=DiscoveryMethod.SSH,
+            )
+
+    def test_https_with_both_discovery_fails_fast(self):
+        """HTTPS cloning with 'both' discovery (needs SSH) must raise."""
+        with pytest.raises(ValueError, match="use_https requires HTTP-based"):
+            Config(
+                host="gerrit.example.org",
+                use_https=True,
+                discovery_method=DiscoveryMethod.BOTH,
+            )
+
+    def test_explicit_ssh_discovery_without_https_is_allowed(self):
+        """Explicit SSH discovery without HTTPS is unaffected."""
+        config = Config(
+            host="gerrit.example.org",
+            discovery_method=DiscoveryMethod.SSH,
+        )
+        assert config.discovery_method == DiscoveryMethod.SSH
+        assert config.port == 29418
+
+    def test_github_derives_github_api_discovery(self):
+        """GitHub sources derive github_api discovery regardless of input."""
+        config = Config(
+            host="github.com",
+            source_type=SourceType.GITHUB,
+            github_token="x",
+        )
+        assert config.discovery_method == DiscoveryMethod.GITHUB_API
+
+    def test_github_coerces_incompatible_discovery_to_api(self):
+        """GitHub coerces SSH/both discovery to github_api."""
+        config = Config(
+            host="github.com",
+            source_type=SourceType.GITHUB,
+            github_token="x",
+            discovery_method=DiscoveryMethod.SSH,
+        )
+        assert config.discovery_method == DiscoveryMethod.GITHUB_API
 
 
 class TestCloneResult:

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -511,11 +511,9 @@ class TestTokenBucketLimiter:
     @pytest.mark.asyncio
     async def test_global_retry_after_blocks_acquire(self) -> None:
         """Acquire should wait when global retry-after is active."""
-        limiter = TokenBucketLimiter(rate=100.0, burst=100)
-
-        # Stateful monotonic: starts at 1000.0, jumps to 1011.0
-        # after the first real sleep so the limiter sees the
-        # deadline as passed on the next loop iteration.
+        # Stateful monotonic: starts at 1000.0, advances by the
+        # sleep duration so the limiter sees the retry-after
+        # deadline as passed after the first sleep.
         current_time = 1000.0
         sleep_durations: list[float] = []
 
@@ -533,6 +531,9 @@ class TestTokenBucketLimiter:
             ),
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
+            # Create limiter INSIDE the patch so _last_refill uses
+            # the fake clock (1000.0) instead of the real monotonic.
+            limiter = TokenBucketLimiter(rate=100.0, burst=100)
             await limiter.set_global_retry_after(10.0)
             await limiter.acquire(tokens=1.0)
 
@@ -779,8 +780,6 @@ class TestTokenBucketLimiterIntegration:
     @pytest.mark.asyncio
     async def test_retry_after_pauses_all_tasks(self) -> None:
         """Global retry-after should pause all tasks."""
-        limiter = TokenBucketLimiter(rate=100.0, burst=100)
-
         # Stateful monotonic: starts at 1000.0, advances by the
         # sleep duration each time fake_sleep is called.
         current_time = 1000.0
@@ -800,6 +799,9 @@ class TestTokenBucketLimiterIntegration:
             ),
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
+            # Create limiter INSIDE the patch so _last_refill uses
+            # the fake clock (1000.0) instead of the real monotonic.
+            limiter = TokenBucketLimiter(rate=100.0, burst=100)
             await limiter.record_rate_limit(retry_after=10.0)
 
             await asyncio.gather(


### PR DESCRIPTION
## Summary

Fixes the failure seen in [`Test Gerrit Clone` run 28012328374](https://github.com/lfreleng-actions/gerrit-clone-action/actions/runs/28012328374), where an HTTPS clone failed during discovery:

```
ERROR  SSH command failed (exit 255): Connection closed by 172.65.51.103 port 443
ERROR  SSH discovery failed
```

### Root cause

`port` is an **SSH-only** concept — HTTP discovery and HTTPS cloning both use `base_url`, never `port`. But two independent defaults combined into an impossible state:

1. `_build_config` mutated `port` to `443` whenever `use_https` was set.
2. The CLI hardcoded `discovery_method="ssh"` as its default.

So `gerrit-clone clone --https` ran **SSH discovery against port 443**, which the proxy fronting the Gerrit host (Cloudflare, `172.65.51.103`) rejects. The composite action masked this with an "auto-select http for HTTPS" workaround; the raw-CLI path did not.

### The fix (simplify + fail fast)

- **`port` is SSH-only and is never derived from the protocol** → SSH discovery can no longer target 443 (the impossible state is gone).
- **`discovery_method` is resolved centrally in `Config.__post_init__`** — the single chokepoint every construction path goes through. It derives from source type and clone protocol: GitHub → `github_api`, Gerrit+HTTPS → `http`, Gerrit+SSH → `ssh`.
- **Contradictions fast-fail**: `use_https` combined with an explicit SSH-requiring discovery method (`ssh`/`both`) now raises a clear configuration error instead of an obscure runtime SSH failure.
- **CLI `--discovery-method` defaults to "derive"** (empty/unset) rather than a fixed `ssh`, so an unset value is distinguishable from an explicit choice.
- **The composite action no longer special-cases HTTPS** — `discovery-method` defaults to empty and is passed through only when set; the CLI derives it.

### Tests

Added regression coverage for the protocol/discovery combinations in `tests/test_models.py` and `tests/test_config.py`:
- HTTPS keeps the SSH port (29418) and derives HTTP discovery
- explicit `ssh`/`both` + HTTPS fast-fail
- GitHub derivation/coercion to `github_api`
- empty-string `discovery_method` is treated as unset and derived

## Commits

1. **`Fix(test): Hang in rate-limit mock tests`** — a self-contained, pre-existing test-setup fix required so the `pytest` pre-commit hook (and CI) don't hang on `main`. (Also present on the in-flight content-filtering branch; harmless if it merges via either route.)
2. **`Fix(config): Prevent SSH discovery on HTTPS port`** — the fix described above.

## Validation

- `ruff`, `ruff-format`, `mypy`, `basedpyright`, `reuse`, `codespell` — pass
- Full non-integration test suite passes (`844 passed` excluding the now-fixed rate-limit file; relevant config/model/CLI suites green)
- Commits are signed and DCO signed-off

🤖 Generated with assistance from Claude (Opus 4.8).