### PR TITLE
Fix: Annotate context manager with Generator type

### DIFF
--- a/src/gerrit_clone/logging.py
+++ b/src/gerrit_clone/logging.py
@@ -21,7 +21,7 @@ from rich.logging import RichHandler
 from rich.theme import Theme
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Generator
 
 # Minimal theme (can be expanded later if reused elsewhere)
 GERRIT_THEME = Theme(
@@ -175,7 +175,7 @@ class _SuppressConsoleFilter(logging.Filter):
 
 
 @contextmanager
-def suppress_console_logging(verbose: bool = False) -> Iterator[None]:
+def suppress_console_logging(verbose: bool = False) -> Generator[None, None, None]:
     """Context manager to temporarily suppress console logging handlers.
 
     This is used during Rich Live display to prevent log messages from

--- a/tests/test_rate_limit.py
+++ b/tests/test_rate_limit.py
@@ -511,11 +511,9 @@ class TestTokenBucketLimiter:
     @pytest.mark.asyncio
     async def test_global_retry_after_blocks_acquire(self) -> None:
         """Acquire should wait when global retry-after is active."""
-        limiter = TokenBucketLimiter(rate=100.0, burst=100)
-
-        # Stateful monotonic: starts at 1000.0, jumps to 1011.0
-        # after the first real sleep so the limiter sees the
-        # deadline as passed on the next loop iteration.
+        # Stateful monotonic: starts at 1000.0, advances by the
+        # sleep duration so the limiter sees the retry-after
+        # deadline as passed after the first sleep.
         current_time = 1000.0
         sleep_durations: list[float] = []
 
@@ -533,6 +531,9 @@ class TestTokenBucketLimiter:
             ),
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
+            # Create limiter INSIDE the patch so _last_refill uses
+            # the fake clock (1000.0) instead of the real monotonic.
+            limiter = TokenBucketLimiter(rate=100.0, burst=100)
             await limiter.set_global_retry_after(10.0)
             await limiter.acquire(tokens=1.0)
 
@@ -779,8 +780,6 @@ class TestTokenBucketLimiterIntegration:
     @pytest.mark.asyncio
     async def test_retry_after_pauses_all_tasks(self) -> None:
         """Global retry-after should pause all tasks."""
-        limiter = TokenBucketLimiter(rate=100.0, burst=100)
-
         # Stateful monotonic: starts at 1000.0, advances by the
         # sleep duration each time fake_sleep is called.
         current_time = 1000.0
@@ -800,6 +799,9 @@ class TestTokenBucketLimiterIntegration:
             ),
             patch("asyncio.sleep", side_effect=fake_sleep),
         ):
+            # Create limiter INSIDE the patch so _last_refill uses
+            # the fake clock (1000.0) instead of the real monotonic.
+            limiter = TokenBucketLimiter(rate=100.0, burst=100)
             await limiter.record_rate_limit(retry_after=10.0)
 
             await asyncio.gather(


### PR DESCRIPTION
## Summary

Clears the single `basedpyright` error currently flagged on `main`:

```
src/gerrit_clone/logging.py:177:2 - error: The function "contextmanager" is deprecated
  Annotating the return type as `-> Iterator[Foo]` with `@contextmanager`
  is deprecated. Use `-> Generator[Foo]` instead.
```

### Root cause

Recent `typeshed` (surfaced by basedpyright 1.39.8 / pyright 1.1.410) deprecates
the `Iterator`-returning overload of `contextlib.contextmanager` in favour of the
`Generator`-returning one. `suppress_console_logging` in `src/gerrit_clone/logging.py`
was the only `@contextmanager` in the codebase still annotated as `Iterator[None]`.

### The fix

- Annotate `suppress_console_logging` as `Generator[None, None, None]` and import
  `Generator` (instead of `Iterator`) under `TYPE_CHECKING`.
- This matches the existing convention already used by the context managers in
  `worker.py` and `concurrent_utils.py`, and is a TYPE_CHECKING-only change with
  zero runtime impact (the module uses `from __future__ import annotations`).

### Test-hang fix (imported)

This branch also includes `Fix(test): Hang in rate-limit mock tests`, a
self-contained, pre-existing test-setup fix. Without it the `pytest` pre-commit
hook (and CI) hang on `main`: two tests constructed a `TokenBucketLimiter` before
patching `time_mod.monotonic`, so `_last_refill` held a real-clock value while the
fake clock started at `1000`, making `acquire()` loop forever. The fix moves limiter
construction inside the patch context. (This same commit also appears in #196; it is
harmless if it merges via either route.)

## Validation

- `basedpyright` (pinned 1.39.8) — the previously failing error is gone; the full
  pre-commit run is green, including `pytest`.
- `ruff`, `mypy`, `reuse`, `codespell` — pass.
- Logging context-manager tests pass.
- Commits are PGP-signed and DCO signed-off.

🤖 Generated with assistance from Claude (Opus 4.8).