### PR TITLE
Feat(refresh): Harden updates and add --force-hard

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,25 @@ Automatically stash uncommitted changes before refresh:
 gerrit-clone refresh --output-path ~/onap --auto-stash
 ```
 
+Force refresh (stash local changes, fix detached HEAD, restore feature-branch
+checkouts to the default branch):
+
+```bash
+gerrit-clone refresh --output-path ~/onap --force
+```
+
+Hard reset: make local content exactly match the remote, discarding local-only
+commits and any divergence. This is the single, explicit way to force-reset
+local content and is a strict superset of `--force`:
+
+```bash
+gerrit-clone refresh --output-path ~/onap --force-hard
+```
+
+> **Note:** `--force-hard` is destructive: it permanently discards
+> local-only commits on the default branch. It leaves other local
+> branches untouched.
+
 Use rebase strategy instead of merge:
 
 ```bash

--- a/src/gerrit_clone/cli.py
+++ b/src/gerrit_clone/cli.py
@@ -861,9 +861,7 @@ def clone(
         remove_file_patterns = (
             normalize_file_patterns([remove_files]) if remove_files else None
         )
-        git_filter_projects = (
-            parse_git_filter_spec(git_filter) if git_filter else None
-        )
+        git_filter_projects = parse_git_filter_spec(git_filter) if git_filter else None
         if remove_file_patterns or git_filter_projects or redact_secrets:
             if not quiet:
                 console.print("[cyan]🔧 Applying content filters...[/cyan]")
@@ -1227,6 +1225,16 @@ def refresh(
             "to your working copies; use with care and recover changes from `git stash` if needed."
         ),
     ),
+    force_hard: bool = typer.Option(
+        False,
+        "--force-hard",
+        help=(
+            "Everything --force does, plus hard-reset each repository's default "
+            "branch to its upstream ref, discarding local commits and "
+            "divergence so local content exactly matches the remote. "
+            "DESTRUCTIVE: local-only commits are permanently lost."
+        ),
+    ),
     recursive: bool = typer.Option(
         True,
         "--recursive / --no-recursive",
@@ -1311,6 +1319,10 @@ def refresh(
         # Auto-stash uncommitted changes
         gerrit-clone refresh --output-path ~/repos --auto-stash
 
+        # Hard-reset local content to exactly match the remote
+        # (discards local-only commits and divergence)
+        gerrit-clone refresh --output-path ~/repos --force-hard
+
         # Dry run (show what would be updated)
         gerrit-clone refresh --output-path ~/repos --dry-run
     """
@@ -1386,7 +1398,13 @@ def refresh(
             f"Exclude Filter: [cyan]{', '.join(exc_display) if exc_display else '—'}[/cyan]"
         )
         console.print(f"Dry Run: [cyan]{dry_run}[/cyan]")
-        console.print(f"Force: [cyan]{force}[/cyan]")
+        # A dry run disables all modifications (see RefreshManager), so report
+        # the *effective* force settings rather than the user-supplied flags to
+        # avoid implying a destructive run when nothing will be changed.
+        effective_force = (force or force_hard) and not dry_run
+        effective_force_hard = force_hard and not dry_run
+        console.print(f"Force: [cyan]{effective_force}[/cyan]")
+        console.print(f"Force Hard: [cyan]{effective_force_hard}[/cyan]")
         console.print(f"Recursive: [cyan]{recursive}[/cyan]")
         console.print()
 
@@ -1406,6 +1424,7 @@ def refresh(
             exit_on_error=exit_on_error,
             dry_run=dry_run,
             force=force,
+            force_hard=force_hard,
             recursive=recursive,
             include_projects=include_projects if include_projects else None,
             exclude_projects=exclude_projects if exclude_projects else None,
@@ -1415,9 +1434,7 @@ def refresh(
         remove_file_patterns = (
             normalize_file_patterns([remove_files]) if remove_files else None
         )
-        git_filter_projects = (
-            parse_git_filter_spec(git_filter) if git_filter else None
-        )
+        git_filter_projects = parse_git_filter_spec(git_filter) if git_filter else None
         if remove_file_patterns or git_filter_projects or redact_secrets:
             if not quiet:
                 console.print("[cyan]🔧 Applying content filters...[/cyan]")
@@ -2201,7 +2218,9 @@ def mirror(
             )
             console.print("[bold]Mirror Summary[/bold]")
             console.print(f"  Discovery Method: [cyan]{discovery_label}[/cyan]")
-            console.print(f"  Clone Protocol: [cyan]{'HTTPS' if use_https else 'SSH'}[/cyan]")
+            console.print(
+                f"  Clone Protocol: [cyan]{'HTTPS' if use_https else 'SSH'}[/cyan]"
+            )
             console.print(f"  Skip Archived: [cyan]{skip_archived}[/cyan]")
             console.print(f"  Total: {batch_result.total_count}")
             console.print(f"  [green]Succeeded: {batch_result.success_count}[/green]")

--- a/src/gerrit_clone/models.py
+++ b/src/gerrit_clone/models.py
@@ -416,9 +416,7 @@ class Config:
                     scheme, bare_host = bare_host.split("://", 1)
                 bare_host = bare_host.split("/", 1)[0]
                 host_lower = bare_host.lower()
-                if host_lower == "github.com" or host_lower.endswith(
-                    ".github.com"
-                ):
+                if host_lower == "github.com" or host_lower.endswith(".github.com"):
                     self.base_url = "https://api.github.com"
                 else:
                     # GitHub Enterprise — preserve the scheme supplied
@@ -498,10 +496,19 @@ class Config:
         Attempts to query performance core count; falls back to 10,
         then caps at 32. For other systems, use heuristic cpu_count * 4.
 
-        For GitHub sources, uses 2x multiplier since operations are network-limited
-        rather than CPU/filesystem-limited. This optimization typically halves
-        clone time for GitHub repositories (e.g., 10 cores -> 20 threads for GitHub,
-        max 64 threads vs 32 for Gerrit).
+        For Gerrit (SSH) sources, the dynamically calculated default is then
+        halved (floor of 1) to reduce the risk of overwhelming a Gerrit
+        server's SSH front-end with too many concurrent handshakes. Bursts of
+        parallel SSH connections are frequently throttled by Gerrit and
+        surface as transient "Could not read from remote repository"
+        failures. Users who want the previous, more aggressive concurrency
+        can still pass ``--threads`` explicitly.
+
+        For GitHub sources the halving does not apply; instead a 2x multiplier
+        is used since operations are network-limited rather than
+        CPU/filesystem-limited. This optimization typically halves clone time
+        for GitHub repositories (e.g., 10 cores -> 20 threads for GitHub,
+        max 64 threads vs 16 halved for Gerrit).
         """
         if self.threads is not None:
             return self.threads
@@ -545,7 +552,12 @@ class Config:
         if self.source_type == SourceType.GITHUB:
             return min(64, base_threads * 2)
 
-        return base_threads
+        # Halve the dynamically calculated default (floor of 1) for Gerrit (SSH)
+        # sources to avoid saturating Gerrit's SSH server with concurrent
+        # handshakes, which can trigger transient "Could not read from remote
+        # repository" errors. GitHub sources are unaffected: they are handled
+        # above with their own higher, network-bound concurrency.
+        return max(1, base_threads // 2)
 
     @property
     def protocol(self) -> str:
@@ -636,7 +648,12 @@ class CloneResult:
         between repos that were updated (REFRESHED with updates) vs merely
         verified as current (VERIFIED or REFRESHED without updates).
         """
-        return self.status in (CloneStatus.SUCCESS, CloneStatus.ALREADY_EXISTS, CloneStatus.REFRESHED, CloneStatus.VERIFIED)
+        return self.status in (
+            CloneStatus.SUCCESS,
+            CloneStatus.ALREADY_EXISTS,
+            CloneStatus.REFRESHED,
+            CloneStatus.VERIFIED,
+        )
 
     @property
     def failed(self) -> bool:
@@ -809,6 +826,11 @@ class RefreshResult:
     had_uncommitted_changes: bool = False
     stash_created: bool = False
     stash_popped: bool = False
+    # Branch the stash was created on. Used to avoid auto-popping a stash onto a
+    # different branch (e.g. after force-mode switches from a feature branch to
+    # the default branch), which could apply changes to the wrong branch.
+    stash_branch: str | None = None
+    hard_reset: bool = False
     detached_head: bool = False
 
     # Retry tracking
@@ -862,6 +884,8 @@ class RefreshResult:
             "had_uncommitted_changes": self.had_uncommitted_changes,
             "stash_created": self.stash_created,
             "stash_popped": self.stash_popped,
+            "stash_branch": self.stash_branch,
+            "hard_reset": self.hard_reset,
             "detached_head": self.detached_head,
             "first_started_at": self.first_started_at.isoformat()
             if self.first_started_at

--- a/src/gerrit_clone/refresh_manager.py
+++ b/src/gerrit_clone/refresh_manager.py
@@ -57,6 +57,7 @@ class RefreshManager:
         exit_on_error: bool = False,
         dry_run: bool = False,
         force: bool = False,
+        force_hard: bool = False,
         recursive: bool = True,
         include_projects: list[str] | None = None,
         exclude_projects: list[str] | None = None,
@@ -77,6 +78,8 @@ class RefreshManager:
             exit_on_error: Exit immediately on first error
             dry_run: Show what would be refreshed without executing
             force: Force refresh by fixing detached HEAD, upstream tracking, and stashing changes
+            force_hard: Superset of force that also hard-resets each repository's
+                default branch to upstream, discarding local commits/divergence
             recursive: Recursively discover repositories in subdirectories (default: True)
             include_projects: Optional list of project name patterns to include.
                 Supports shell-style wildcards (*, ?, [seq]) and hierarchical
@@ -97,6 +100,7 @@ class RefreshManager:
         self.exit_on_error = exit_on_error
         self.dry_run = dry_run
         self.force = force
+        self.force_hard = force_hard
         self.recursive = recursive
         self.include_projects = include_projects
         self.exclude_projects = exclude_projects
@@ -107,9 +111,11 @@ class RefreshManager:
         elif config is not None:
             self.threads = config.effective_threads
         else:
-            # Default to CPU count * 4, capped at 32
+            # Default to CPU count * 4, capped at 32, then halved (floor of 1)
+            # to reduce concurrent SSH handshakes against Gerrit and avoid
+            # transient "Could not read from remote repository" throttling.
             cpu_count = os.cpu_count() or 4
-            self.threads = min(32, cpu_count * 4)
+            self.threads = max(1, min(32, cpu_count * 4) // 2)
 
         logger.debug(f"RefreshManager initialized with {self.threads} threads")
 
@@ -314,6 +320,7 @@ class RefreshManager:
             strategy=self.strategy,
             filter_gerrit_only=self.filter_gerrit_only,
             force=self.force,
+            force_hard=self.force_hard,
         )
 
         # Create progress display with two-line layout
@@ -337,7 +344,10 @@ class RefreshManager:
 
         with (
             Live(
-                display_group, console=Console(stderr=True), refresh_per_second=4, transient=False
+                display_group,
+                console=Console(stderr=True),
+                refresh_per_second=4,
+                transient=False,
             ),
             interruptible_executor(
                 max_workers=self.threads,
@@ -426,6 +436,7 @@ class RefreshManager:
             strategy=self.strategy,
             filter_gerrit_only=self.filter_gerrit_only,
             force=False,  # Never force modifications in dry run
+            force_hard=False,  # Never hard-reset in dry run
         )
 
         for repo_path in repo_paths:
@@ -546,6 +557,7 @@ def refresh_repositories(
     exit_on_error: bool = False,
     dry_run: bool = False,
     force: bool = False,
+    force_hard: bool = False,
     recursive: bool = True,
 ) -> RefreshBatchResult:
     """Refresh repositories in a directory.
@@ -568,6 +580,8 @@ def refresh_repositories(
         exit_on_error: Exit immediately on first error
         dry_run: Show what would be refreshed without executing
         force: Force refresh by fixing detached HEAD, upstream tracking, and stashing changes
+        force_hard: Superset of force that also hard-resets each repository's
+            default branch to upstream, discarding local commits/divergence
         recursive: Recursively discover repositories in subdirectories (default: True)
 
     Returns:
@@ -588,6 +602,7 @@ def refresh_repositories(
         exit_on_error=exit_on_error,
         dry_run=dry_run,
         force=force,
+        force_hard=force_hard,
         recursive=recursive,
     )
 

--- a/src/gerrit_clone/refresh_worker.py
+++ b/src/gerrit_clone/refresh_worker.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import time
 from datetime import UTC, datetime
+from enum import Enum
 from typing import TYPE_CHECKING, Any
 
 from gerrit_clone.git_utils import is_git_repository
@@ -21,6 +22,76 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 logger = get_logger(__name__)
+
+# Maximum random delay (seconds) inserted before each SSH-backed git network
+# operation. Spreading handshakes across a small window de-synchronises worker
+# threads so we do not open many simultaneous SSH connections to Gerrit, which
+# is a common cause of transient "Could not read from remote repository"
+# throttling failures.
+SSH_HANDSHAKE_JITTER_SECONDS = 0.25
+
+# Transient SSH / network failures that are safe to retry. Gerrit prints some of
+# these (notably "could not read from remote repository") for genuine
+# authentication failures too, so callers MUST check for authentication markers
+# (see ``_AUTH_ERROR_PATTERNS``) BEFORE treating an error as transient.
+_TRANSIENT_GIT_ERROR_PATTERNS = (
+    "could not read from remote repository",
+    "early eof",
+    "the remote end hung up unexpectedly",
+    "kex_exchange_identification",
+    "ssh_exchange_identification",
+    "connection closed by remote host",
+    "connection reset by peer",
+    "connection reset",
+    "broken pipe",
+)
+
+# Markers that unambiguously indicate an authentication / authorization failure.
+_AUTH_ERROR_PATTERNS = (
+    "permission denied",
+    "publickey",
+    "authentication failed",
+    "access denied",
+)
+
+# Markers indicating the remote repository does not exist (or is not visible as
+# a project). Gerrit and GitHub also print the generic "could not read from
+# remote repository" line for a missing repo, so callers MUST check these
+# BEFORE the transient patterns to avoid misclassifying a permanently missing
+# repository as a retryable network blip.
+_NOT_FOUND_GIT_ERROR_PATTERNS = (
+    "repository not found",
+    "does not exist",
+)
+
+# Markers indicating the local branch has diverged from upstream and a
+# fast-forward-only update is not possible (i.e. local commits exist).
+_DIVERGED_BRANCH_PATTERNS = (
+    "diverging branches",
+    "not possible to fast-forward",
+    "can't be fast-forwarded",
+    "cannot be fast-forwarded",
+)
+
+
+class StashOutcome(Enum):
+    """Result of attempting to stash a working tree.
+
+    ``git stash push`` exits 0 both when it stashes changes and when it finds
+    nothing to stash (for example a working tree whose only modification is a
+    submodule gitlink, which git stash does not capture). Distinguishing these
+    lets callers avoid both a spurious "failed to stash" error and a later
+    "failed to restore stash" warning for a stash that was never created.
+    """
+
+    CREATED = "created"
+    """A new stash entry was created."""
+
+    NOTHING_TO_STASH = "nothing_to_stash"
+    """The command succeeded but there was nothing git could stash."""
+
+    FAILED = "failed"
+    """The stash command errored."""
 
 
 class RefreshError(Exception):
@@ -46,6 +117,8 @@ class RefreshWorker:
         strategy: str = "merge",
         filter_gerrit_only: bool = True,
         force: bool = False,
+        force_hard: bool = False,
+        ssh_jitter_seconds: float = SSH_HANDSHAKE_JITTER_SECONDS,
     ) -> None:
         """Initialize refresh worker.
 
@@ -60,6 +133,11 @@ class RefreshWorker:
             strategy: Git pull strategy ('merge' or 'rebase')
             filter_gerrit_only: Only refresh repositories with Gerrit remotes
             force: Force refresh by fixing detached HEAD, upstream tracking, and stashing changes
+            force_hard: Superset of ``force`` that additionally hard-resets the
+                default branch to its upstream ref, discarding local commits and
+                divergence. Implies ``force``.
+            ssh_jitter_seconds: Maximum random delay before each SSH-backed git
+                network operation, used to de-synchronise concurrent handshakes.
         """
         self.config = config
         self.retry_policy = retry_policy or RetryPolicy()
@@ -70,7 +148,10 @@ class RefreshWorker:
         self.auto_stash = auto_stash
         self.strategy = strategy
         self.filter_gerrit_only = filter_gerrit_only
-        self.force = force
+        # force_hard is a strict superset of force.
+        self.force_hard = force_hard
+        self.force = force or force_hard
+        self.ssh_jitter_seconds = max(0.0, ssh_jitter_seconds)
 
     def refresh_repository(self, repo_path: Path) -> RefreshResult:
         """Refresh a single repository.
@@ -169,6 +250,53 @@ class RefreshWorker:
                         logger.error(f"❌ {project_name}: Failed to fix detached HEAD")
                         return result
 
+                # Force mode: if parked on a non-default feature branch, switch
+                # back to the default branch so we refresh the mainline rather
+                # than local feature work. Use a local-only default-branch lookup
+                # first to avoid an extra networked ls-remote per repository.
+                default_branch: str | None = None
+                if result.current_branch and not result.detached_head:
+                    default_branch = self._get_default_branch_local(repo_path)
+                    if default_branch is None:
+                        default_branch = self._get_default_branch(repo_path)
+                    if default_branch and result.current_branch != default_branch:
+                        logger.debug(
+                            f"🔧 {project_name}: Switching from feature branch "
+                            f"'{result.current_branch}' to default branch '{default_branch}'"
+                        )
+                        # Stash first so an unclean tree cannot block checkout.
+                        if (
+                            result.had_uncommitted_changes
+                            and not result.stash_created
+                            and self._stash_changes(repo_path) is StashOutcome.CREATED
+                        ):
+                            result.stash_created = True
+                            # Record the branch the stash came from so it is
+                            # not auto-popped onto the default branch after
+                            # the switch below (that would apply
+                            # feature-branch work to the wrong branch).
+                            result.stash_branch = result.current_branch
+                            # Tree is now clean; clear the dirty flag so the
+                            # later force-mode stash does not try to re-stash
+                            # a clean tree if the checkout below fails.
+                            result.had_uncommitted_changes = False
+                        if self._switch_to_default_branch(repo_path, default_branch):
+                            state = self._check_repository_state(repo_path)
+                            result.current_branch = state.get("branch")
+                            result.detached_head = state.get("detached_head", False)
+                            result.had_uncommitted_changes = state.get(
+                                "has_uncommitted", False
+                            )
+                            logger.debug(
+                                f"✓ {project_name}: Switched to default branch "
+                                f"'{result.current_branch}'"
+                            )
+                        else:
+                            logger.warning(
+                                f"⚠️ {project_name}: Could not switch to default "
+                                f"branch '{default_branch}', refreshing current branch"
+                            )
+
                 # Fix upstream tracking
                 if not state.get("has_upstream", False) and result.current_branch:
                     logger.debug(
@@ -217,8 +345,18 @@ class RefreshWorker:
                     logger.debug(
                         f"💾 {project_name}: Force stashing uncommitted changes"
                     )
-                    if self._stash_changes(repo_path):
+                    stash_outcome = self._stash_changes(repo_path)
+                    if stash_outcome is StashOutcome.CREATED:
                         result.stash_created = True
+                        result.stash_branch = result.current_branch
+                    elif stash_outcome is StashOutcome.NOTHING_TO_STASH:
+                        # Nothing git could stash (e.g. a modified submodule
+                        # gitlink). Not an error and nothing to restore later.
+                        result.had_uncommitted_changes = False
+                        logger.debug(
+                            f"💾 {project_name}: Nothing to stash "
+                            f"(e.g. submodule-only change)"
+                        )
                     else:
                         result.status = RefreshStatus.FAILED
                         result.error_message = (
@@ -230,6 +368,42 @@ class RefreshWorker:
                         ).total_seconds()
                         logger.error(f"❌ {project_name}: Failed to stash changes")
                         return result
+
+                # Force-hard mode: discard any local commits / divergence by
+                # hard-resetting the default branch to its upstream ref. This
+                # is the single, explicit way to make local content exactly
+                # match the remote; the normal pull that follows is then a
+                # no-op fast-forward.
+                #
+                # Guard the reset so it only ever touches the default branch.
+                # If the default branch could not be determined or the switch
+                # to it failed above, we are still parked on a feature branch;
+                # hard-resetting it would silently discard local-only commits,
+                # which contradicts the documented "default branch only"
+                # contract. Skip the reset in that case.
+                if self.force_hard and result.current_branch:
+                    on_default_branch = (
+                        default_branch is not None
+                        and result.current_branch == default_branch
+                    )
+                    if not on_default_branch:
+                        logger.warning(
+                            f"⚠️ {project_name}: Not on the default branch "
+                            f"(on '{result.current_branch}', default "
+                            f"'{default_branch}'); skipping hard reset to avoid "
+                            f"discarding local commits"
+                        )
+                    elif self._reset_to_upstream(repo_path, result):
+                        result.hard_reset = True
+                        logger.debug(
+                            f"🧨 {project_name}: Hard reset '{result.current_branch}' "
+                            f"to upstream"
+                        )
+                    else:
+                        logger.warning(
+                            f"⚠️ {project_name}: Hard reset to upstream failed "
+                            f"(no upstream?), continuing with pull"
+                        )
             else:
                 # Normal mode: Skip problematic repos
                 # Handle detached HEAD state
@@ -273,9 +447,18 @@ class RefreshWorker:
                     return result
                 elif self.auto_stash:
                     # Stash uncommitted changes
-                    if self._stash_changes(repo_path):
+                    stash_outcome = self._stash_changes(repo_path)
+                    if stash_outcome is StashOutcome.CREATED:
                         result.stash_created = True
+                        result.stash_branch = result.current_branch
                         logger.debug(f"💾 {project_name}: Stashed uncommitted changes")
+                    elif stash_outcome is StashOutcome.NOTHING_TO_STASH:
+                        # Nothing git could stash (e.g. a modified submodule
+                        # gitlink); proceed with the refresh as if clean.
+                        logger.debug(
+                            f"💾 {project_name}: Nothing to stash "
+                            f"(e.g. submodule-only change)"
+                        )
                     else:
                         result.status = RefreshStatus.FAILED
                         result.error_message = "Failed to stash uncommitted changes"
@@ -306,9 +489,25 @@ class RefreshWorker:
                     result.status = RefreshStatus.UP_TO_DATE
                     logger.debug(f"✓ {project_name}: Already up-to-date")
 
-                # Pop stash if we created one
+                # Pop stash if we created one, but only back onto the branch it
+                # came from. In force mode the stash may have been taken on a
+                # feature branch before switching to the default branch; popping
+                # it here would apply that work to the wrong branch (and drop
+                # the stash entry). In that case leave the stash intact for
+                # manual recovery.
                 if result.stash_created:
-                    if self._pop_stash(repo_path):
+                    stashed_elsewhere = (
+                        result.stash_branch is not None
+                        and result.current_branch != result.stash_branch
+                    )
+                    if stashed_elsewhere:
+                        logger.warning(
+                            f"⚠️ {project_name}: Stash was created on "
+                            f"'{result.stash_branch}' but the working tree is now "
+                            f"on '{result.current_branch}'; leaving the stash "
+                            f"intact for manual recovery (git stash list)"
+                        )
+                    elif self._pop_stash(repo_path):
                         result.stash_popped = True
                         logger.debug(f"💾 {project_name}: Restored stashed changes")
                     else:
@@ -406,6 +605,10 @@ class RefreshWorker:
         result.attempts += 1
         attempt_start = datetime.now(UTC)
 
+        # Spread out SSH handshakes across concurrent workers to avoid Gerrit
+        # throttling a burst of simultaneous connections.
+        self._ssh_handshake_jitter(repo_path)
+
         try:
             if self.fetch_only:
                 # Fetch only, don't merge
@@ -457,6 +660,8 @@ class RefreshWorker:
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=self.timeout,
                 check=False,
             )
@@ -511,6 +716,8 @@ class RefreshWorker:
                 env=env,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=self.timeout,
                 check=False,
             )
@@ -569,6 +776,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -632,6 +841,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -651,6 +862,8 @@ class RefreshWorker:
                         cwd=repo_path,
                         capture_output=True,
                         text=True,
+                        encoding="utf-8",
+                        errors="replace",
                         timeout=5,
                         check=False,
                     )
@@ -664,6 +877,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -676,16 +891,23 @@ class RefreshWorker:
 
         return state
 
-    def _stash_changes(self, repo_path: Path) -> bool:
+    def _stash_changes(self, repo_path: Path) -> StashOutcome:
         """Stash uncommitted changes.
+
+        ``git stash push`` exits 0 even when it stashes nothing (most commonly
+        when the only change is a modified submodule gitlink, which git stash
+        does not capture). We therefore confirm a new stash entry was actually
+        created so callers can distinguish CREATED from NOTHING_TO_STASH and
+        never attempt to pop a stash that does not exist.
 
         Args:
             repo_path: Repository path
 
         Returns:
-            True if stash succeeded
+            The :class:`StashOutcome` describing what happened.
         """
         try:
+            before = self._stash_count(repo_path)
             result = subprocess.run(
                 [
                     "git",
@@ -698,15 +920,33 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=False,
             )
 
-            return result.returncode == 0
+            if result.returncode != 0:
+                return StashOutcome.FAILED
+
+            # Confirm a stash entry actually appeared. git prints "No local
+            # changes to save" and exits 0 when there was nothing to stash.
+            after = self._stash_count(repo_path)
+            if before >= 0 and after >= 0:
+                return (
+                    StashOutcome.CREATED
+                    if after > before
+                    else StashOutcome.NOTHING_TO_STASH
+                )
+
+            # Counts unavailable: fall back to sniffing git's message.
+            if "no local changes to save" in result.stdout.lower():
+                return StashOutcome.NOTHING_TO_STASH
+            return StashOutcome.CREATED
 
         except Exception as e:
             logger.debug(f"Failed to stash changes: {e}")
-            return False
+            return StashOutcome.FAILED
 
     def _is_on_meta_config(self, repo_path: Path) -> bool:
         """Check if repository is currently on Gerrit's meta/config branch.
@@ -724,6 +964,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -738,6 +980,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -765,12 +1009,17 @@ class RefreshWorker:
             True if repo only has meta/* refs and no regular branches
         """
         try:
-            # List all remote heads (branches)
+            # List all remote heads (branches). ls-remote is an SSH-backed
+            # network operation for Gerrit, so de-sync the handshake to avoid
+            # bursty concurrent connections under high worker counts.
+            self._ssh_handshake_jitter(repo_path)
             result = subprocess.run(
                 ["git", "ls-remote", "--heads", "origin"],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
             )
@@ -787,6 +1036,8 @@ class RefreshWorker:
                     cwd=repo_path,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                     check=False,
                 )
@@ -820,12 +1071,18 @@ class RefreshWorker:
         """
         try:
             # First, try to query the remote directly for HEAD
-            # This works even if we haven't fetched recently
+            # This works even if we haven't fetched recently. ls-remote is an
+            # SSH-backed network operation for Gerrit remotes, so de-sync the
+            # handshake here too to avoid the same throttling _perform_refresh
+            # guards against under high concurrency.
+            self._ssh_handshake_jitter(repo_path)
             ls_remote_result = subprocess.run(
                 ["git", "ls-remote", "--symref", "origin", "HEAD"],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
             )
@@ -850,6 +1107,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -869,6 +1128,8 @@ class RefreshWorker:
                     cwd=repo_path,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=5,
                     check=False,
                 )
@@ -907,12 +1168,17 @@ class RefreshWorker:
                 )
 
             # Fetch remote to ensure we have latest branch info
-            # This is crucial for repos that might not have been fetched recently
+            # This is crucial for repos that might not have been fetched recently.
+            # git fetch opens an SSH connection for Gerrit, so de-sync the
+            # handshake to avoid contributing to concurrent-connection throttling.
+            self._ssh_handshake_jitter(repo_path)
             fetch_result = subprocess.run(
                 ["git", "fetch", "--quiet", "origin"],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=False,
             )
@@ -944,6 +1210,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=False,
             )
@@ -964,6 +1232,8 @@ class RefreshWorker:
                     cwd=repo_path,
                     capture_output=True,
                     text=True,
+                    encoding="utf-8",
+                    errors="replace",
                     timeout=10,
                     check=False,
                 )
@@ -981,6 +1251,208 @@ class RefreshWorker:
         except Exception as e:
             logger.debug(f"Failed to fix detached HEAD: {e}")
             return False
+
+    def _get_default_branch_local(self, repo_path: Path) -> str | None:
+        """Determine the default branch using only local refs (no network).
+
+        Reads the locally cached ``refs/remotes/origin/HEAD`` symbolic ref, which
+        gerrit-clone sets at clone time. Returns None if it is not available so
+        callers can decide whether a networked lookup is warranted.
+
+        Args:
+            repo_path: Repository path
+
+        Returns:
+            Default branch name, or None if it cannot be determined locally
+        """
+        try:
+            result = subprocess.run(
+                ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                check=False,
+            )
+            if result.returncode == 0:
+                ref = result.stdout.strip()
+                # "origin/master" -> "master"
+                branch = ref.split("/", 1)[1] if ref.startswith("origin/") else ref
+                if branch and not branch.startswith("meta/"):
+                    return branch
+            return None
+        except Exception as e:
+            logger.debug(f"Failed to get local default branch: {e}")
+            return None
+
+    def _switch_to_default_branch(self, repo_path: Path, default_branch: str) -> bool:
+        """Check out the default branch and set its upstream tracking.
+
+        Unlike ``_fix_detached_head`` this is intended for repositories that are
+        on a (non-default) local feature branch rather than in a detached HEAD
+        state, and it does not perform meta/config or parent-project detection.
+
+        Args:
+            repo_path: Repository path
+            default_branch: Name of the branch to check out
+
+        Returns:
+            True if the branch was checked out successfully
+        """
+        try:
+            checkout_result = subprocess.run(
+                ["git", "checkout", default_branch],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+
+            if checkout_result.returncode != 0:
+                logger.debug(
+                    f"Failed to checkout '{default_branch}': {checkout_result.stderr}"
+                )
+                return False
+
+            # Best-effort: ensure upstream tracking is set for the default branch.
+            subprocess.run(
+                [
+                    "git",
+                    "branch",
+                    f"--set-upstream-to=origin/{default_branch}",
+                    default_branch,
+                ],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=10,
+                check=False,
+            )
+            return True
+
+        except Exception as e:
+            logger.debug(f"Failed to switch to default branch: {e}")
+            return False
+
+    def _reset_to_upstream(self, repo_path: Path, result: RefreshResult) -> bool:
+        """Hard-reset the current branch to its upstream tracking ref.
+
+        This discards any local commits and divergence so that local content
+        exactly matches the remote. Used by force-hard mode. The subsequent pull
+        then fast-forwards cleanly (typically a no-op).
+
+        Args:
+            repo_path: Repository path
+            result: Result object with current branch info
+
+        Returns:
+            True if the reset succeeded
+        """
+        if not result.current_branch:
+            return False
+
+        try:
+            # Verify the branch has an upstream to reset to.
+            upstream_check = subprocess.run(
+                [
+                    "git",
+                    "rev-parse",
+                    "--abbrev-ref",
+                    f"{result.current_branch}@{{upstream}}",
+                ],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=5,
+                check=False,
+            )
+            if upstream_check.returncode != 0:
+                logger.debug(
+                    f"No upstream for '{result.current_branch}', cannot hard reset"
+                )
+                return False
+
+            reset_result = subprocess.run(
+                ["git", "reset", "--hard", f"{result.current_branch}@{{upstream}}"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+
+            if reset_result.returncode == 0:
+                return True
+
+            logger.debug(f"Hard reset failed: {reset_result.stderr}")
+            return False
+
+        except Exception as e:
+            logger.debug(f"Failed to hard reset to upstream: {e}")
+            return False
+
+    @staticmethod
+    def _remote_uses_ssh(remote_url: str | None) -> bool:
+        """Return True if the origin remote performs an SSH handshake.
+
+        Only SSH-backed remotes benefit from handshake jitter. HTTP(S), the
+        anonymous git protocol, ``file://`` URLs and local filesystem paths
+        never open an SSH connection, so jittering them just adds latency. An
+        unknown/empty remote is treated as SSH so the throttling protection is
+        preserved when the URL cannot be read.
+
+        Args:
+            remote_url: The origin remote URL, or None if it is unknown.
+
+        Returns:
+            True if a handshake (and therefore jitter) is warranted.
+        """
+        if not remote_url:
+            return True
+        url = remote_url.strip()
+        lowered = url.lower()
+        if lowered.startswith("ssh://"):
+            return True
+        # Non-SSH transports and local paths never open an SSH handshake.
+        if lowered.startswith(("http://", "https://", "git://", "file://")):
+            return False
+        if url.startswith(("/", "./", "../", "~")):
+            return False
+        # scp-like syntax (``[user@]host:path``) is SSH. git only recognises it
+        # when a colon appears before the first slash; a colon after a slash
+        # (or no colon at all) denotes a local filesystem path.
+        colon = url.find(":")
+        slash = url.find("/")
+        return colon != -1 and (slash == -1 or colon < slash)
+
+    def _ssh_handshake_jitter(self, repo_path: Path) -> None:
+        """Sleep a small random interval before an SSH-backed git operation.
+
+        De-synchronises concurrent worker threads so we avoid opening many
+        simultaneous SSH connections to Gerrit, which is a common cause of
+        transient "Could not read from remote repository" throttling. The
+        sleep is skipped for HTTP(S)/git-protocol remotes, which perform no
+        SSH handshake and so gain nothing from jitter.
+
+        Args:
+            repo_path: Repository whose origin remote is about to be contacted.
+        """
+        if self.ssh_jitter_seconds <= 0:
+            return
+        if not self._remote_uses_ssh(self._get_remote_url(repo_path)):
+            return
+        time.sleep(random.uniform(0, self.ssh_jitter_seconds))
 
     def _fix_upstream_tracking(self, repo_path: Path, result: RefreshResult) -> bool:
         """Fix upstream tracking by setting it to origin/<branch>.
@@ -1002,6 +1474,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=5,
                 check=False,
             )
@@ -1023,6 +1497,8 @@ class RefreshWorker:
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=10,
                 check=False,
             )
@@ -1043,27 +1519,80 @@ class RefreshWorker:
     def _pop_stash(self, repo_path: Path) -> bool:
         """Pop stashed changes.
 
+        ``git stash pop`` can exit non-zero even when the working-tree changes
+        were applied and the stash entry was dropped. The most common cause in
+        practice is a submodule gitlink whose status reporting produces a
+        non-zero exit even though nothing failed (e.g. a repository with a
+        dirty or advanced submodule pointer). A genuine failure (a merge
+        conflict) leaves the stash entry in place, so we treat a dropped stash
+        as success regardless of the exit status.
+
         Args:
             repo_path: Repository path
 
         Returns:
-            True if pop succeeded
+            True if pop succeeded (changes applied and stash dropped)
         """
         try:
+            before = self._stash_count(repo_path)
             result = subprocess.run(
                 ["git", "stash", "pop"],
                 cwd=repo_path,
                 capture_output=True,
                 text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=30,
                 check=False,
             )
 
-            return result.returncode == 0
+            if result.returncode == 0:
+                return True
+
+            # Non-zero exit: fall back to checking whether the stash entry was
+            # actually consumed. If it was, the changes were applied and the
+            # non-zero status is spurious (typically submodule status noise).
+            after = self._stash_count(repo_path)
+            if before > 0 and 0 <= after < before:
+                logger.debug(
+                    "Stash applied despite non-zero git exit "
+                    "(likely submodule status noise)"
+                )
+                return True
+
+            return False
 
         except Exception as e:
             logger.debug(f"Failed to pop stash: {e}")
             return False
+
+    def _stash_count(self, repo_path: Path) -> int:
+        """Return the number of entries in the repository's stash list.
+
+        Args:
+            repo_path: Repository path
+
+        Returns:
+            Number of stash entries, or -1 if the count could not be
+            determined.
+        """
+        try:
+            result = subprocess.run(
+                ["git", "stash", "list"],
+                cwd=repo_path,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=30,
+                check=False,
+            )
+            if result.returncode != 0:
+                return -1
+            return sum(1 for line in result.stdout.splitlines() if line.strip())
+        except Exception as e:
+            logger.debug(f"Failed to count stash entries: {e}")
+            return -1
 
     def _build_git_environment(self) -> dict[str, str]:
         """Build environment for Git operations.
@@ -1156,20 +1685,35 @@ class RefreshWorker:
         ):
             return f"Network error during {operation}"
 
-        # Authentication errors
-        if any(
-            phrase in combined
-            for phrase in [
-                "permission denied",
-                "authentication failed",
-                "could not read",
-            ]
-        ):
+        # Authentication errors. Checked BEFORE transient SSH errors because
+        # Gerrit prints a generic "Could not read from remote repository" line
+        # for auth failures too; the "permission denied"/"publickey" markers
+        # disambiguate a real auth failure from transient throttling.
+        if any(phrase in combined for phrase in _AUTH_ERROR_PATTERNS):
             return f"Authentication error during {operation}"
 
-        # Repository errors
-        if "repository not found" in combined or "does not exist" in combined:
+        # Repository not found. Checked BEFORE the transient SSH patterns
+        # because a missing repository also produces the generic "could not
+        # read from remote repository" line; without this ordering a
+        # permanently missing repo would be misreported as a transient network
+        # error and needlessly retried.
+        if any(phrase in combined for phrase in _NOT_FOUND_GIT_ERROR_PATTERNS):
             return f"Repository not found during {operation}"
+
+        # Transient SSH / connection failures (e.g. Gerrit throttling a burst of
+        # concurrent connections). Reported as a network error so the retry
+        # logic treats them as retryable.
+        if any(phrase in combined for phrase in _TRANSIENT_GIT_ERROR_PATTERNS):
+            return f"Network error during {operation}"
+
+        # Diverging branches: local commits prevent a fast-forward-only update.
+        # git's wording ("Diverging branches can't be fast-forwarded") does not
+        # contain "non-fast-forward", so it must be matched explicitly.
+        if any(phrase in combined for phrase in _DIVERGED_BRANCH_PATTERNS):
+            return (
+                f"Diverging branches during {operation}: local commits differ "
+                f"from upstream; use --force-hard to reset to the remote"
+            )
 
         # Merge conflicts
         if "conflict" in combined:
@@ -1203,30 +1747,48 @@ class RefreshWorker:
         stdout = process_result.stdout.lower()
         combined = stderr + stdout
 
-        # Retryable: network errors
+        # Authentication / authorization failures are never retryable. Check
+        # these FIRST: Gerrit prints a generic "could not read from remote
+        # repository" line (which also appears for transient throttling) on real
+        # auth failures, so the "permission denied"/"publickey" markers are what
+        # distinguish them and must take precedence.
+        if any(pattern in combined for pattern in _AUTH_ERROR_PATTERNS):
+            return False
+
+        # Missing repositories are never retryable. Check BEFORE the transient
+        # patterns: Gerrit/GitHub also print "could not read from remote
+        # repository" when a project does not exist, so without this ordering a
+        # permanently missing repo would match a transient pattern and be
+        # retried pointlessly.
+        if any(pattern in combined for pattern in _NOT_FOUND_GIT_ERROR_PATTERNS):
+            return False
+
+        # Retryable: network and transient SSH handshake failures. The transient
+        # SSH patterns (e.g. "could not read from remote repository", "early
+        # EOF", "kex_exchange_identification") cover Gerrit throttling a burst of
+        # concurrent connections, which succeeds on retry.
         retryable_patterns = [
             "could not resolve host",
             "failed to connect",
             "connection timed out",
             "connection refused",
-            "connection reset",
-            "broken pipe",
             "temporary failure",
             "try again",
+            *_TRANSIENT_GIT_ERROR_PATTERNS,
         ]
 
         for pattern in retryable_patterns:
             if pattern in combined:
                 return True
 
-        # Non-retryable: authentication, conflicts, etc.
+        # Non-retryable: conflicts, divergence, etc. (missing repositories are
+        # handled earlier, before the transient-pattern check).
         non_retryable_patterns = [
-            "permission denied",
             "authentication failed",
             "conflict",
             "non-fast-forward",
             "rejected",
-            "repository not found",
+            *_DIVERGED_BRANCH_PATTERNS,
         ]
 
         for pattern in non_retryable_patterns:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -255,6 +255,26 @@ class TestConfig:
         assert threads > 0
         assert threads <= 32
 
+    def test_effective_threads_github_not_halved(self):
+        """GitHub keeps its 2x multiplier; only Gerrit is halved."""
+        gerrit = Config(host="gerrit.example.org", source_type=SourceType.GERRIT)
+        github = Config(
+            host="github.com",
+            source_type=SourceType.GITHUB,
+            github_token="x",
+        )
+
+        gerrit_threads = gerrit.effective_threads
+        github_threads = github.effective_threads
+
+        # Gerrit is halved and capped at 32; GitHub is boosted and capped at 64.
+        assert 1 <= gerrit_threads <= 32
+        assert github_threads <= 64
+        # The Gerrit-only halving must not cancel GitHub's 2x multiplier, so
+        # GitHub concurrency stays well above the halved Gerrit value.
+        assert github_threads > gerrit_threads
+        assert github_threads >= gerrit_threads * 2
+
     def test_projects_url(self):
         """Test projects_url property."""
         config = Config(host="gerrit.example.org")

--- a/tests/test_refresh_worker.py
+++ b/tests/test_refresh_worker.py
@@ -7,12 +7,17 @@ from __future__ import annotations
 
 import subprocess
 from datetime import UTC, datetime
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 import pytest
 
 from gerrit_clone.models import Config, RefreshResult, RefreshStatus, RetryPolicy
-from gerrit_clone.refresh_worker import RefreshTimeoutError, RefreshWorker
+from gerrit_clone.refresh_worker import (
+    RefreshTimeoutError,
+    RefreshWorker,
+    StashOutcome,
+)
 
 
 @pytest.fixture
@@ -21,6 +26,10 @@ def worker():
     return RefreshWorker(
         retry_policy=RetryPolicy(max_attempts=2, base_delay=0.1),
         timeout=10,
+        # Disable SSH handshake jitter so its remote-URL lookup does not
+        # perturb tests that mock subprocess.run for the network helpers.
+        # Dedicated jitter tests construct their own workers.
+        ssh_jitter_seconds=0,
     )
 
 
@@ -276,8 +285,8 @@ class TestRefreshWorker:
         # Create uncommitted changes
         (temp_git_repo / "uncommitted.txt").write_text("uncommitted")
 
-        success = worker._stash_changes(temp_git_repo)
-        assert success is True
+        outcome = worker._stash_changes(temp_git_repo)
+        assert outcome is StashOutcome.CREATED
 
         # Verify working directory is clean
         result = subprocess.run(
@@ -288,6 +297,11 @@ class TestRefreshWorker:
             check=True,
         )
         assert result.stdout.strip() == ""
+
+    def test_stash_changes_nothing_to_stash(self, worker, temp_git_repo):
+        """A clean tree yields NOTHING_TO_STASH, not a failure."""
+        outcome = worker._stash_changes(temp_git_repo)
+        assert outcome is StashOutcome.NOTHING_TO_STASH
 
     def test_pop_stash(self, worker, temp_git_repo):
         """Test popping stashed changes."""
@@ -1169,3 +1183,500 @@ class TestFixUpstreamTracking:
         success = worker._fix_upstream_tracking(temp_git_repo, result)
 
         assert success is False
+
+
+class TestTransientAndDivergedClassification:
+    """Classification of transient SSH and diverged-branch failures."""
+
+    def test_analyze_transient_ssh_is_network(self, worker):
+        """Transient SSH failures are reported as retryable network errors."""
+        process_result = Mock()
+        process_result.returncode = 128
+        process_result.stdout = ""
+        process_result.stderr = "fatal: Could not read from remote repository."
+
+        assert "Network error" in worker._analyze_git_error(process_result, "pull")
+
+    def test_transient_ssh_is_retryable(self, worker):
+        """SSH handshake throttling is retryable."""
+        process_result = Mock()
+        process_result.returncode = 128
+        process_result.stdout = ""
+        process_result.stderr = (
+            "kex_exchange_identification: Connection closed by remote host"
+        )
+
+        assert worker._is_retryable_git_error(process_result) is True
+
+    def test_auth_with_could_not_read_still_non_retryable(self, worker):
+        """Real auth failures print 'could not read' too but must not retry."""
+        process_result = Mock()
+        process_result.returncode = 128
+        process_result.stdout = ""
+        process_result.stderr = (
+            "Permission denied (publickey).\n"
+            "fatal: Could not read from remote repository."
+        )
+
+        assert worker._is_retryable_git_error(process_result) is False
+        assert "Authentication error" in worker._analyze_git_error(
+            process_result, "pull"
+        )
+
+    def test_analyze_diverging_branches(self, worker):
+        """Diverging branches are recognised and hint at --force-hard."""
+        process_result = Mock()
+        process_result.returncode = 1
+        process_result.stdout = ""
+        process_result.stderr = "hint: Diverging branches can't be fast-forwarded"
+
+        msg = worker._analyze_git_error(process_result, "pull")
+        assert "Diverging branches" in msg
+        assert "force-hard" in msg.lower()
+
+    def test_diverging_branches_non_retryable(self, worker):
+        """Diverging branches are not retryable."""
+        process_result = Mock()
+        process_result.returncode = 1
+        process_result.stdout = ""
+        process_result.stderr = "hint: Diverging branches can't be fast-forwarded"
+
+        assert worker._is_retryable_git_error(process_result) is False
+
+    def test_diverging_with_transfer_stats_first_line(self, worker):
+        """Transfer stats before the hint must not mask the divergence."""
+        process_result = Mock()
+        process_result.returncode = 1
+        process_result.stdout = ""
+        process_result.stderr = (
+            "Total 5 (delta 3), reused 5 (delta 3)\n"
+            "hint: Diverging branches can't be fast-forwarded"
+        )
+
+        assert "Diverging branches" in worker._analyze_git_error(process_result, "pull")
+
+    def test_missing_repo_with_could_not_read_is_not_found(self, worker):
+        """Missing repos print 'could not read' too but are not transient."""
+        process_result = Mock()
+        process_result.returncode = 128
+        process_result.stdout = ""
+        process_result.stderr = (
+            "fatal: 'nonexistent' does not exist\n"
+            "fatal: Could not read from remote repository."
+        )
+
+        assert "Repository not found" in worker._analyze_git_error(
+            process_result, "fetch"
+        )
+
+    def test_missing_repo_is_not_retryable(self, worker):
+        """A missing repository must not be retried as a network blip."""
+        process_result = Mock()
+        process_result.returncode = 128
+        process_result.stdout = ""
+        process_result.stderr = (
+            "ERROR: Repository not found.\n"
+            "fatal: Could not read from remote repository."
+        )
+
+        assert worker._is_retryable_git_error(process_result) is False
+
+
+class TestPopStashSubmoduleNoise:
+    """Tests for stash-pop success detection under submodule status noise."""
+
+    def test_pop_stash_success_returns_true(self, worker, temp_git_repo):
+        """A clean pop (exit 0) is reported as success."""
+        (temp_git_repo / "uncommitted.txt").write_text("uncommitted")
+        worker._stash_changes(temp_git_repo)
+
+        assert worker._pop_stash(temp_git_repo) is True
+        assert (temp_git_repo / "uncommitted.txt").read_text() == "uncommitted"
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_pop_stash_nonzero_but_dropped_is_success(self, mock_run, worker):
+        """Non-zero pop that still drops the stash counts as success.
+
+        Reproduces the submodule-gitlink case where ``git stash pop`` applies
+        the working-tree changes and drops the stash entry but exits non-zero
+        because of submodule status reporting.
+        """
+        pop = Mock(returncode=1, stdout="", stderr="error in submodule")
+        before = Mock(returncode=0, stdout="stash@{0}: WIP\n", stderr="")
+        after = Mock(returncode=0, stdout="", stderr="")
+        # Call order: _stash_count (before), stash pop, _stash_count (after)
+        mock_run.side_effect = [before, pop, after]
+
+        assert worker._pop_stash(Path("/tmp/repo")) is True
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_pop_stash_nonzero_and_retained_is_failure(self, mock_run, worker):
+        """Non-zero pop that leaves the stash in place is a real failure."""
+        pop = Mock(returncode=1, stdout="", stderr="CONFLICT (content)")
+        before = Mock(returncode=0, stdout="stash@{0}: WIP\n", stderr="")
+        after = Mock(returncode=0, stdout="stash@{0}: WIP\n", stderr="")
+        mock_run.side_effect = [before, pop, after]
+
+        assert worker._pop_stash(Path("/tmp/repo")) is False
+
+
+class TestForceHard:
+    """Tests for force-hard behaviour and its helpers."""
+
+    def test_force_hard_implies_force(self):
+        """--force-hard is a superset of --force."""
+        worker = RefreshWorker(force_hard=True)
+        assert worker.force is True
+        assert worker.force_hard is True
+
+    def test_force_default_not_hard(self):
+        """--force alone does not enable hard reset."""
+        worker = RefreshWorker(force=True)
+        assert worker.force is True
+        assert worker.force_hard is False
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_reset_to_upstream_success(self, mock_run, worker, temp_git_repo):
+        """Hard reset succeeds when an upstream exists."""
+        upstream_check = Mock(returncode=0, stdout="origin/master", stderr="")
+        reset = Mock(returncode=0, stdout="", stderr="")
+        mock_run.side_effect = [upstream_check, reset]
+
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+        result.current_branch = "master"
+
+        assert worker._reset_to_upstream(temp_git_repo, result) is True
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_reset_to_upstream_no_upstream(self, mock_run, worker, temp_git_repo):
+        """Hard reset is skipped when there is no upstream to reset to."""
+        upstream_check = Mock(returncode=128, stdout="", stderr="fatal: no upstream")
+        mock_run.side_effect = [upstream_check]
+
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+        result.current_branch = "master"
+
+        assert worker._reset_to_upstream(temp_git_repo, result) is False
+
+    def test_reset_to_upstream_no_branch(self, worker, temp_git_repo):
+        """Hard reset requires a current branch."""
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+        result.current_branch = None
+
+        assert worker._reset_to_upstream(temp_git_repo, result) is False
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_switch_to_default_branch_success(self, mock_run, worker, temp_git_repo):
+        """Switching to the default branch checks it out and sets upstream."""
+        checkout = Mock(returncode=0, stdout="", stderr="")
+        set_upstream = Mock(returncode=0, stdout="", stderr="")
+        mock_run.side_effect = [checkout, set_upstream]
+
+        assert worker._switch_to_default_branch(temp_git_repo, "master") is True
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_switch_to_default_branch_checkout_fails(
+        self, mock_run, worker, temp_git_repo
+    ):
+        """A failed checkout is reported as failure."""
+        checkout = Mock(returncode=1, stdout="", stderr="error: pathspec")
+        mock_run.side_effect = [checkout]
+
+        assert worker._switch_to_default_branch(temp_git_repo, "master") is False
+
+    def test_force_hard_skips_reset_when_not_on_default(self, temp_git_repo):
+        """Force-hard must not hard-reset a feature branch on switch failure."""
+        worker = RefreshWorker(force_hard=True, filter_gerrit_only=False)
+        state = {
+            "branch": "feature/x",
+            "detached_head": False,
+            "has_uncommitted": False,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        with (
+            patch.object(worker, "_check_repository_state", return_value=state),
+            patch.object(worker, "_get_default_branch_local", return_value="main"),
+            patch.object(worker, "_switch_to_default_branch", return_value=False),
+            patch.object(worker, "_reset_to_upstream") as mock_reset,
+            patch.object(worker, "_execute_adaptive_refresh", return_value=True),
+        ):
+            result = worker.refresh_repository(temp_git_repo)
+
+        # Still parked on the feature branch, so the destructive reset that
+        # would discard its local-only commits must be skipped.
+        mock_reset.assert_not_called()
+        assert result.hard_reset is False
+
+    def test_force_hard_resets_on_default_branch(self, temp_git_repo):
+        """Force-hard hard-resets when already on the default branch."""
+        worker = RefreshWorker(force_hard=True, filter_gerrit_only=False)
+        state = {
+            "branch": "main",
+            "detached_head": False,
+            "has_uncommitted": False,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        with (
+            patch.object(worker, "_check_repository_state", return_value=state),
+            patch.object(worker, "_get_default_branch_local", return_value="main"),
+            patch.object(worker, "_reset_to_upstream", return_value=True) as mock_reset,
+            patch.object(worker, "_execute_adaptive_refresh", return_value=True),
+        ):
+            result = worker.refresh_repository(temp_git_repo)
+
+        mock_reset.assert_called_once()
+        assert result.hard_reset is True
+
+    def test_force_preswitch_stash_clears_dirty_flag(self, temp_git_repo):
+        """A successful pre-switch stash prevents a redundant second stash."""
+        worker = RefreshWorker(force_hard=True, filter_gerrit_only=False)
+        state = {
+            "branch": "feature/x",
+            "detached_head": False,
+            "has_uncommitted": True,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        with (
+            patch.object(worker, "_check_repository_state", return_value=state),
+            patch.object(worker, "_get_default_branch_local", return_value="main"),
+            patch.object(worker, "_switch_to_default_branch", return_value=False),
+            patch.object(
+                worker, "_stash_changes", return_value=StashOutcome.CREATED
+            ) as mock_stash,
+            patch.object(worker, "_reset_to_upstream") as mock_reset,
+            patch.object(worker, "_execute_adaptive_refresh", return_value=True),
+        ):
+            result = worker.refresh_repository(temp_git_repo)
+
+        # The tree is stashed once before the (failed) switch; the later
+        # "always stash" block must not re-stash a now-clean tree.
+        mock_stash.assert_called_once()
+        mock_reset.assert_not_called()
+        assert result.stash_created is True
+
+    def test_force_stash_not_popped_on_different_branch(self, temp_git_repo):
+        """A stash taken on a feature branch is not popped onto default."""
+        worker = RefreshWorker(force=True, filter_gerrit_only=False)
+        feature_state = {
+            "branch": "feature/x",
+            "detached_head": False,
+            "has_uncommitted": True,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        main_state = {
+            "branch": "main",
+            "detached_head": False,
+            "has_uncommitted": False,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        pending = [feature_state]
+
+        def fake_state(_repo):
+            return pending.pop(0) if pending else main_state
+
+        with (
+            patch.object(worker, "_check_repository_state", side_effect=fake_state),
+            patch.object(worker, "_get_default_branch_local", return_value="main"),
+            patch.object(worker, "_stash_changes", return_value=StashOutcome.CREATED),
+            patch.object(worker, "_switch_to_default_branch", return_value=True),
+            patch.object(worker, "_pop_stash") as mock_pop,
+            patch.object(worker, "_execute_adaptive_refresh", return_value=True),
+        ):
+            result = worker.refresh_repository(temp_git_repo)
+
+        # Stash came from feature/x but we ended on main, so it must be left
+        # intact rather than popped onto the wrong branch.
+        mock_pop.assert_not_called()
+        assert result.stash_created is True
+        assert result.stash_popped is False
+        assert result.stash_branch == "feature/x"
+        assert result.current_branch == "main"
+
+    def test_force_nothing_to_stash_does_not_fail_or_pop(self, temp_git_repo):
+        """A submodule-only dirty tree (nothing to stash) is benign.
+
+        Reproduces the ci-management case: the only change is a modified
+        submodule gitlink, which git stash does not capture, so no stash is
+        created. Force mode must not fail, must not set stash_created, and must
+        not attempt (and warn about) a pop of a non-existent stash.
+        """
+        worker = RefreshWorker(force=True, filter_gerrit_only=False)
+        state = {
+            "branch": "master",
+            "detached_head": False,
+            "has_uncommitted": True,
+            "has_upstream": True,
+            "on_meta_config": False,
+        }
+        with (
+            patch.object(worker, "_check_repository_state", return_value=state),
+            patch.object(worker, "_get_default_branch_local", return_value="master"),
+            patch.object(
+                worker,
+                "_stash_changes",
+                return_value=StashOutcome.NOTHING_TO_STASH,
+            ),
+            patch.object(worker, "_pop_stash") as mock_pop,
+            patch.object(worker, "_execute_adaptive_refresh", return_value=True),
+        ):
+            result = worker.refresh_repository(temp_git_repo)
+
+        assert result.status is not RefreshStatus.FAILED
+        assert result.stash_created is False
+        assert result.stash_popped is False
+        mock_pop.assert_not_called()
+
+
+class TestSshJitter:
+    """Tests for SSH handshake jitter."""
+
+    def test_jitter_zero_no_sleep(self):
+        """Zero jitter performs no sleep."""
+        worker = RefreshWorker(ssh_jitter_seconds=0)
+        with patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep:
+            worker._ssh_handshake_jitter(Path("/tmp/repo"))
+            mock_sleep.assert_not_called()
+
+    def test_jitter_positive_sleeps_within_bounds(self):
+        """Positive jitter sleeps within [0, ssh_jitter_seconds] for SSH."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        with (
+            patch.object(
+                worker, "_get_remote_url", return_value="ssh://gerrit:29418/x"
+            ),
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            worker._ssh_handshake_jitter(Path("/tmp/repo"))
+            mock_sleep.assert_called_once()
+            slept = mock_sleep.call_args[0][0]
+            assert 0 <= slept <= 0.1
+
+    def test_jitter_skipped_for_http_remote(self):
+        """HTTP(S) remotes perform no SSH handshake, so jitter is skipped."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        with (
+            patch.object(
+                worker,
+                "_get_remote_url",
+                return_value="https://github.com/org/repo.git",
+            ),
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            worker._ssh_handshake_jitter(Path("/tmp/repo"))
+            mock_sleep.assert_not_called()
+
+    def test_jitter_applied_for_scp_style_ssh_remote(self):
+        """scp-style user@host:path remotes are treated as SSH."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        with (
+            patch.object(
+                worker, "_get_remote_url", return_value="git@github.com:org/repo.git"
+            ),
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            worker._ssh_handshake_jitter(Path("/tmp/repo"))
+            mock_sleep.assert_called_once()
+
+    def test_jitter_applied_for_unknown_remote(self):
+        """An unreadable remote conservatively still jitters."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        with (
+            patch.object(worker, "_get_remote_url", return_value=None),
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            worker._ssh_handshake_jitter(Path("/tmp/repo"))
+            mock_sleep.assert_called_once()
+
+    def test_jitter_skipped_for_file_and_local_remotes(self):
+        """file:// URLs and local paths perform no SSH handshake."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        for url in ("file:///srv/git/repo.git", "/srv/git/repo.git", "../peer"):
+            with (
+                patch.object(worker, "_get_remote_url", return_value=url),
+                patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+            ):
+                worker._ssh_handshake_jitter(Path("/tmp/repo"))
+                mock_sleep.assert_not_called()
+
+    def test_remote_uses_ssh_classification(self):
+        """Direct classification of remote URL transports."""
+        ssh = RefreshWorker._remote_uses_ssh
+        assert ssh("ssh://gerrit.example.org:29418/proj") is True
+        assert ssh("git@github.com:org/repo.git") is True
+        assert ssh(None) is True  # unknown -> conservative
+        assert ssh("https://github.com/org/repo.git") is False
+        assert ssh("http://example.org/repo.git") is False
+        assert ssh("git://example.org/repo.git") is False
+        assert ssh("file:///srv/git/repo.git") is False
+        assert ssh("/srv/git/repo.git") is False
+        assert ssh("./peer") is False
+        assert ssh("~/repos/peer") is False
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_get_default_branch_applies_jitter(self, mock_run, temp_git_repo):
+        """Networked default-branch lookup is preceded by SSH jitter."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="ref: refs/heads/main\tHEAD\n",
+            stderr="",
+        )
+        with patch.object(worker, "_ssh_handshake_jitter") as mock_jitter:
+            branch = worker._get_default_branch(temp_git_repo)
+
+        mock_jitter.assert_called_once()
+        assert branch == "main"
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_is_meta_only_repo_applies_jitter(self, mock_run, temp_git_repo):
+        """The networked meta-only check is preceded by SSH jitter."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        mock_run.return_value = Mock(
+            returncode=0,
+            stdout="abc123\trefs/heads/main\n",
+            stderr="",
+        )
+        with patch.object(worker, "_ssh_handshake_jitter") as mock_jitter:
+            worker._is_meta_only_repo(temp_git_repo)
+
+        mock_jitter.assert_called()
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_fix_detached_head_applies_jitter(self, mock_run, temp_git_repo):
+        """The networked detached-HEAD fetch is preceded by SSH jitter."""
+        worker = RefreshWorker(ssh_jitter_seconds=0.1)
+        mock_run.return_value = Mock(returncode=0, stdout="", stderr="")
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+        with (
+            patch.object(worker, "_is_on_meta_config", return_value=False),
+            patch.object(worker, "_get_default_branch", return_value="main"),
+            patch.object(worker, "_ssh_handshake_jitter") as mock_jitter,
+        ):
+            worker._fix_detached_head(temp_git_repo, result)
+
+        mock_jitter.assert_called()


### PR DESCRIPTION
## Summary

Hardens `gerrit-clone refresh` so that transient and recoverable failures
no longer require a blunt, destructive `--force`, and adds a single
opt-in flag for a genuine hard reset of local content.

This addresses a batch of refresh failures observed while refreshing the
full ONAP estate on a case-insensitive macOS filesystem under high
concurrency, where several repositories failed for reasons that were
recoverable but misclassified.

## Changes

1. **Reclassify transient SSH errors as retryable.** Auth markers
   (`permission denied` / `publickey`) are now checked first; genuinely
   transient failures (throttled SSH handshakes, connection resets) are
   retried instead of being reported as authentication errors.
2. **Recognise diverging-branch wording** (`can't be fast-forwarded`)
   and surface a clear message hinting at `--force-hard`.
3. **Robust output decoding** — all `subprocess.run` calls in the
   refresh worker decode with `errors="replace"`, fixing hard failures
   on non-UTF-8 bytes in git output.
4. **New `--force-hard` flag** — a superset of `--force` that also resets
   the default branch to its upstream (`@{upstream}`), giving a single
   flag for a deliberate hard reset. `force_hard` implies `force`.
5. **Feature-branch switch in force mode** — refresh switches to the
   default branch (looked up locally to avoid an extra network round
   trip) before updating, and preserves other local branches.
6. **Halve the default worker/thread count** — the dynamically
   calculated concurrency is halved to reduce SSH handshake throttling
   against Gerrit.
7. **SSH handshake jitter** — small randomised delay before each SSH
   handshake to further de-synchronise concurrent connections.

## Validation

- Full test suite: **1073 passed**.
- `ruff` and `mypy` clean for the changed files.
- Verified end-to-end against a diverged + feature-branch scenario in a
  real ONAP repo: `--force-hard` correctly switched to the default
  branch, reset to upstream, and preserved unrelated local branches.

Co-authored-by: Claude <noreply@anthropic.com>