### PR TITLE
Fix(refresh): Harden Gerrit SSH throttle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,18 @@ reliability, speed, and CI/CD compatibility.
 - **Bulk Repository Discovery**: Fetches all projects via Gerrit REST API with
   intelligent filtering
 - **Multi-threaded Cloning**: Concurrent operations with auto-scaling thread
-  pools (up to 32 workers for Gerrit, 64 for GitHub with 2x multiplier for
-  network-limited operations)
+  pools (Gerrit uses a conservative auto-default of at most 8 concurrent SSH
+  sessions to avoid server-side throttling; GitHub uses up to 64 with a 2x
+  multiplier; override either with `--threads`)
 - **Hierarchy Preservation**: Maintains complete Gerrit project folder
   structure without flattening
 - **Complete Metadata Cloning**: Uses `git clone --mirror` by default to
   capture all refs, tags, and branches for complete repository backups
 - **GitHub Mirroring**: Mirror Gerrit repositories to GitHub organizations
   with automatic name transformation
-- **Robust Retry Logic**: Exponential backoff with jitter for transient
-  network and server failures
+- **Robust Retry Logic**: Exponential backoff with full jitter for transient
+  network and server failures, including a small bounded retry for Gerrit SSH
+  throttling that can surface as a transient "Permission denied" rejection
 - **SSH Integration**: Full SSH agent, identity file, and config support
 - **CI/CD Ready**: Non-interactive operation with structured JSON manifests
 - **Smart Filtering**: Automatically excludes system repos and archived

--- a/src/gerrit_clone/models.py
+++ b/src/gerrit_clone/models.py
@@ -15,6 +15,13 @@ from enum import Enum
 from pathlib import Path
 from typing import Any
 
+# Absolute ceiling on concurrent SSH sessions to a Gerrit server for the
+# auto-computed default thread count. The real constraint is the server's
+# per-user SSH connection limit, not local CPU, so cap independently of core
+# count to avoid throttling on high-core machines. Users can still override the
+# default explicitly with ``--threads``.
+_MAX_GERRIT_THREADS = 8
+
 
 class ProjectState(str, Enum):
     """Gerrit project states."""
@@ -501,8 +508,10 @@ class Config:
         server's SSH front-end with too many concurrent handshakes. Bursts of
         parallel SSH connections are frequently throttled by Gerrit and
         surface as transient "Could not read from remote repository"
-        failures. Users who want the previous, more aggressive concurrency
-        can still pass ``--threads`` explicitly.
+        failures. The halved value is additionally capped at
+        ``_MAX_GERRIT_THREADS`` since the binding constraint is the server's
+        per-user SSH connection limit rather than local CPU. Users who want a
+        different concurrency can still pass ``--threads`` explicitly.
 
         For GitHub sources the halving does not apply; instead a 2x multiplier
         is used since operations are network-limited rather than
@@ -555,9 +564,12 @@ class Config:
         # Halve the dynamically calculated default (floor of 1) for Gerrit (SSH)
         # sources to avoid saturating Gerrit's SSH server with concurrent
         # handshakes, which can trigger transient "Could not read from remote
-        # repository" errors. GitHub sources are unaffected: they are handled
-        # above with their own higher, network-bound concurrency.
-        return max(1, base_threads // 2)
+        # repository" errors. The result is additionally capped at
+        # _MAX_GERRIT_THREADS because the real limit is the server's per-user
+        # SSH connection count, not local core count. GitHub sources are
+        # unaffected: they are handled above with their own higher, network-bound
+        # concurrency.
+        return max(1, min(base_threads // 2, _MAX_GERRIT_THREADS))
 
     @property
     def protocol(self) -> str:

--- a/src/gerrit_clone/refresh_worker.py
+++ b/src/gerrit_clone/refresh_worker.py
@@ -587,7 +587,11 @@ class RefreshWorker:
                 auth_attempt += 1
                 result.retry_count += 1
                 if auth_attempt < max_auth_attempts:
-                    delay = self._calculate_adaptive_delay(auth_attempt)
+                    # Base the backoff on the overall attempt counter, not the
+                    # smaller auth counter, so an auth failure following earlier
+                    # network retries does not reset exponential backoff and
+                    # re-collide with a throttled Gerrit.
+                    delay = self._calculate_adaptive_delay(attempt)
                     logger.warning(
                         f"⚠️ {result.project_name}: {e} (auth attempt {auth_attempt}/{max_auth_attempts}), retrying in {delay:.1f}s"
                     )
@@ -664,10 +668,12 @@ class RefreshWorker:
 
             return success
 
-        except (RefreshError, RefreshTimeoutError, RefreshAuthError):
+        except RefreshError:
             # Already-classified refresh errors (auth, timeout, transient)
             # propagate unchanged so the retry loop applies the correct retry
             # budget instead of re-wrapping them as a generic error.
+            # RefreshTimeoutError and RefreshAuthError both subclass
+            # RefreshError, so catching the base class covers all three.
             raise
 
         except subprocess.TimeoutExpired as err:
@@ -721,9 +727,14 @@ class RefreshWorker:
                 return True
             else:
                 error_msg = self._analyze_git_error(process_result, "fetch")
-                result.error_message = error_msg
 
+                # Raise first for retryable errors: the same RefreshResult
+                # is reused across retry attempts, so recording the message
+                # now would leave it stale on a later successful attempt.
+                # Only record it for non-retryable (hard) failures, which
+                # is when this call returns normally.
                 self._raise_for_retryable_git_error(process_result, error_msg)
+                result.error_message = error_msg
                 return False
 
         except subprocess.TimeoutExpired as err:
@@ -776,18 +787,25 @@ class RefreshWorker:
                 return True
             else:
                 error_msg = self._analyze_git_error(process_result, "pull")
-                result.error_message = error_msg
 
-                # Check for conflicts
+                # Check for conflicts (a hard failure: always record the
+                # message).
                 if (
                     "CONFLICT" in process_result.stdout
                     or "CONFLICT" in process_result.stderr
                 ):
+                    result.error_message = error_msg
                     result.status = RefreshStatus.CONFLICTS
                     logger.error(f"⚠️ {result.project_name}: Merge conflicts detected")
                     return False
 
+                # Raise first for retryable errors: the same RefreshResult
+                # is reused across retry attempts, so recording the message
+                # now would leave it stale on a later successful attempt.
+                # Only record it for non-retryable (hard) failures, which
+                # is when this call returns normally.
                 self._raise_for_retryable_git_error(process_result, error_msg)
+                result.error_message = error_msg
                 return False
 
         except subprocess.TimeoutExpired as err:

--- a/src/gerrit_clone/refresh_worker.py
+++ b/src/gerrit_clone/refresh_worker.py
@@ -73,6 +73,14 @@ _DIVERGED_BRANCH_PATTERNS = (
     "cannot be fast-forwarded",
 )
 
+# Auth-classified failures are normally fatal, but a Gerrit server throttling a
+# burst of concurrent SSH connections can reject a valid key with "Permission
+# denied (publickey)" while it drops the connection. Retrying such a failure a
+# small, bounded number of times recovers these transient throttles, whereas a
+# genuinely misconfigured key still fails quickly instead of consuming the full
+# network-retry budget across every repository.
+_MAX_AUTH_RETRY_ATTEMPTS = 2
+
 
 class StashOutcome(Enum):
     """Result of attempting to stash a working tree.
@@ -100,6 +108,17 @@ class RefreshError(Exception):
 
 class RefreshTimeoutError(RefreshError):
     """Raised when refresh operation times out."""
+
+
+class RefreshAuthError(RefreshError):
+    """Raised when a refresh fails with an authentication-style error.
+
+    Kept distinct from :class:`RefreshError` so the retry loop can apply a
+    small, dedicated retry budget: a throttled Gerrit may reject a valid key
+    with "Permission denied (publickey)" while dropping a connection, which a
+    couple of retries recover, whereas a genuine auth misconfiguration should
+    fail without consuming the full network-retry budget.
+    """
 
 
 class RefreshWorker:
@@ -544,7 +563,14 @@ class RefreshWorker:
             True if refresh succeeded, False otherwise
         """
         max_attempts = self.retry_policy.max_attempts
+        # Auth-style failures get a smaller, dedicated retry budget (see
+        # _MAX_AUTH_RETRY_ATTEMPTS): a throttled Gerrit can reject a valid key
+        # while dropping a connection, which a couple of retries recover, but a
+        # real auth misconfiguration should not consume the full network-retry
+        # budget.
+        max_auth_attempts = min(max_attempts, _MAX_AUTH_RETRY_ATTEMPTS)
         attempt = 0
+        auth_attempt = 0
 
         while attempt < max_attempts:
             attempt += 1
@@ -556,6 +582,22 @@ class RefreshWorker:
                 # If we get here, refresh failed but didn't raise exception
                 # (non-retryable error)
                 return False
+
+            except RefreshAuthError as e:
+                auth_attempt += 1
+                result.retry_count += 1
+                if auth_attempt < max_auth_attempts:
+                    delay = self._calculate_adaptive_delay(auth_attempt)
+                    logger.warning(
+                        f"⚠️ {result.project_name}: {e} (auth attempt {auth_attempt}/{max_auth_attempts}), retrying in {delay:.1f}s"
+                    )
+                    time.sleep(delay)
+                else:
+                    logger.error(
+                        f"❌ {result.project_name}: {e} (auth retries exhausted)"
+                    )
+                    result.error_message = str(e)
+                    return False
 
             except RefreshTimeoutError:
                 result.retry_count += 1
@@ -622,6 +664,12 @@ class RefreshWorker:
 
             return success
 
+        except (RefreshError, RefreshTimeoutError, RefreshAuthError):
+            # Already-classified refresh errors (auth, timeout, transient)
+            # propagate unchanged so the retry loop applies the correct retry
+            # budget instead of re-wrapping them as a generic error.
+            raise
+
         except subprocess.TimeoutExpired as err:
             error_msg = f"Git operation timeout after {self.timeout}s"
             result.error_message = error_msg
@@ -675,10 +723,8 @@ class RefreshWorker:
                 error_msg = self._analyze_git_error(process_result, "fetch")
                 result.error_message = error_msg
 
-                if self._is_retryable_git_error(process_result):
-                    raise RefreshError(error_msg)
-                else:
-                    return False
+                self._raise_for_retryable_git_error(process_result, error_msg)
+                return False
 
         except subprocess.TimeoutExpired as err:
             raise RefreshTimeoutError(f"Fetch timeout after {self.timeout}s") from err
@@ -741,10 +787,8 @@ class RefreshWorker:
                     logger.error(f"⚠️ {result.project_name}: Merge conflicts detected")
                     return False
 
-                if self._is_retryable_git_error(process_result):
-                    raise RefreshError(error_msg)
-                else:
-                    return False
+                self._raise_for_retryable_git_error(process_result, error_msg)
+                return False
 
         except subprocess.TimeoutExpired as err:
             raise RefreshTimeoutError(f"Pull timeout after {self.timeout}s") from err
@@ -1732,6 +1776,56 @@ class RefreshWorker:
 
         return f"Git {operation} failed with exit code {process_result.returncode}"
 
+    def _is_auth_git_error(
+        self, process_result: subprocess.CompletedProcess[str]
+    ) -> bool:
+        """Determine if a failed Git result looks like an authentication error.
+
+        A throttled Gerrit can surface a transient connection-limit drop as a
+        "Permission denied (publickey)" rejection, so auth-classified errors are
+        retried a small, bounded number of times (see
+        ``_MAX_AUTH_RETRY_ATTEMPTS``) rather than treated as immediately fatal.
+
+        Args:
+            process_result: Completed process result
+
+        Returns:
+            True if the failure carries authentication markers
+        """
+        combined = (process_result.stderr + process_result.stdout).lower()
+
+        # Missing repositories are never auth errors. Check first so a
+        # permanently absent repo is not misclassified as a retryable auth
+        # throttle.
+        if any(pattern in combined for pattern in _NOT_FOUND_GIT_ERROR_PATTERNS):
+            return False
+
+        return any(pattern in combined for pattern in _AUTH_ERROR_PATTERNS)
+
+    def _raise_for_retryable_git_error(
+        self, process_result: subprocess.CompletedProcess[str], error_msg: str
+    ) -> None:
+        """Raise the appropriate retryable error for a failed Git result.
+
+        Raises :class:`RefreshAuthError` for auth-style failures (which get a
+        small, bounded retry budget) and :class:`RefreshError` for transient
+        network/SSH failures (full retry budget). Returns normally when the
+        failure is not retryable, letting the caller treat it as a hard
+        failure.
+
+        Args:
+            process_result: Completed process result
+            error_msg: Human-readable error message for the raised exception
+
+        Raises:
+            RefreshAuthError: If the failure looks like an auth error
+            RefreshError: If the failure is a retryable transient error
+        """
+        if self._is_auth_git_error(process_result):
+            raise RefreshAuthError(error_msg)
+        if self._is_retryable_git_error(process_result):
+            raise RefreshError(error_msg)
+
     def _is_retryable_git_error(
         self, process_result: subprocess.CompletedProcess[str]
     ) -> bool:
@@ -1838,9 +1932,12 @@ class RefreshWorker:
 
         # Add jitter if enabled
         if self.retry_policy.jitter:
-            jitter_factor = 0.2  # 20% jitter
-            jitter = random.uniform(-jitter_factor * delay, jitter_factor * delay)
-            delay = max(0.1, delay + jitter)
+            # Full jitter: pick a random point in [0, delay]. This
+            # de-synchronises retries from a burst of workers that failed
+            # together (e.g. a Gerrit SSH throttle), preventing them from
+            # re-colliding on the next attempt. A small floor keeps a minimum
+            # spacing between attempts.
+            delay = max(0.1, random.uniform(0.0, delay))
 
         return delay
 

--- a/tests/integration/test_github_clone.py
+++ b/tests/integration/test_github_clone.py
@@ -93,6 +93,9 @@ class TestGitHubClone:
             include_projects=["gerrit-clone-action"],  # Known repo
             threads=1,
             mirror=False,  # Use regular clone (not bare) for testing
+            # Clone over HTTPS with the token so this passes on fork PRs,
+            # which do not receive the SSH deploy secret.
+            use_https=True,
         )
 
         # Discover and verify the repository exists
@@ -133,6 +136,7 @@ class TestGitHubClone:
             include_projects=["gerrit-clone-action"],
             depth=1,
             threads=1,
+            use_https=True,
         )
 
         # Clone the repository
@@ -157,6 +161,7 @@ class TestGitHubClone:
             path=tmp_clone_dir,
             threads=4,  # Use multiple threads
             skip_archived=True,
+            use_https=True,
         )
 
         # Clone repositories (limit to first 5 for speed)
@@ -187,6 +192,7 @@ class TestGitHubClone:
             path=tmp_clone_dir,
             include_projects=["gerrit-clone-action"],
             threads=1,
+            use_https=True,
         )
 
         # First clone
@@ -227,6 +233,7 @@ class TestGitHubClone:
             include_projects=["gerrit-clone-action"],
             threads=1,
             auto_refresh=False,  # Disable auto-refresh
+            use_https=True,
         )
 
         # First clone

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from datetime import UTC, datetime
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -274,6 +275,17 @@ class TestConfig:
         # GitHub concurrency stays well above the halved Gerrit value.
         assert github_threads > gerrit_threads
         assert github_threads >= gerrit_threads * 2
+
+    def test_effective_threads_gerrit_capped(self):
+        """The auto Gerrit default is capped by the per-user SSH ceiling."""
+        # Force a high core count on a non-Darwin path so the halved default
+        # would exceed the ceiling without the cap.
+        with (
+            patch("gerrit_clone.models.platform.system", return_value="Linux"),
+            patch("gerrit_clone.models.os.cpu_count", return_value=64),
+        ):
+            gerrit = Config(host="gerrit.example.org", source_type=SourceType.GERRIT)
+            assert gerrit.effective_threads == 8
 
     def test_projects_url(self):
         """Test projects_url property."""

--- a/tests/test_refresh_worker.py
+++ b/tests/test_refresh_worker.py
@@ -14,6 +14,8 @@ import pytest
 
 from gerrit_clone.models import Config, RefreshResult, RefreshStatus, RetryPolicy
 from gerrit_clone.refresh_worker import (
+    RefreshAuthError,
+    RefreshError,
     RefreshTimeoutError,
     RefreshWorker,
     StashOutcome,
@@ -398,14 +400,19 @@ class TestRefreshWorker:
         assert worker._is_retryable_error("Permission denied") is False
 
     def test_calculate_adaptive_delay(self, worker):
-        """Test adaptive delay calculation."""
-        delay1 = worker._calculate_adaptive_delay(1)
-        delay2 = worker._calculate_adaptive_delay(2)
-        delay3 = worker._calculate_adaptive_delay(3)
-
-        # Delays should increase exponentially
-        assert delay2 > delay1
-        assert delay3 > delay2
+        """Full-jitter delay stays within [0.1, exponential bound]."""
+        # Full jitter picks a random point in [0, exponential-bound] with a
+        # 0.1s floor, so assert bounds across many samples rather than strict
+        # monotonicity (which no longer holds by design).
+        base = worker.retry_policy.base_delay
+        factor = worker.retry_policy.factor
+        max_delay = worker.retry_policy.max_delay
+        for attempt in (1, 2, 3):
+            bound = min(base * (factor ** (attempt - 1)), max_delay)
+            upper = max(0.1, bound)
+            for _ in range(50):
+                delay = worker._calculate_adaptive_delay(attempt)
+                assert 0.1 <= delay <= upper
 
     def test_count_pulled_commits_fast_forward(self, worker):
         """Test counting commits from fast-forward output."""
@@ -1280,6 +1287,116 @@ class TestTransientAndDivergedClassification:
         )
 
         assert worker._is_retryable_git_error(process_result) is False
+
+
+class TestAuthRetryBudget:
+    """Bounded retry handling for auth-classified (throttle) failures."""
+
+    def _make_result(self) -> RefreshResult:
+        """Build a minimal pending RefreshResult for retry-loop tests."""
+        return RefreshResult(
+            path=Path("/tmp/repo"),
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+
+    def test_is_auth_git_error_detects_permission_denied(self, worker):
+        """A permission-denied failure is classified as an auth error."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = (
+            "Permission denied (publickey).\n"
+            "fatal: Could not read from remote repository."
+        )
+        assert worker._is_auth_git_error(process_result) is True
+
+    def test_is_auth_git_error_not_found_is_not_auth(self, worker):
+        """A missing repository is not treated as an auth error."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = (
+            "ERROR: Repository not found.\n"
+            "fatal: Could not read from remote repository."
+        )
+        assert worker._is_auth_git_error(process_result) is False
+
+    def test_is_auth_git_error_transient_is_not_auth(self, worker):
+        """A bare SSH throttle (no auth marker) is not an auth error."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = (
+            "kex_exchange_identification: Connection closed by remote host"
+        )
+        assert worker._is_auth_git_error(process_result) is False
+
+    def test_raise_for_auth_error_raises_refresh_auth_error(self, worker):
+        """Auth failures raise RefreshAuthError for the bounded budget."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = "Permission denied (publickey)."
+        with pytest.raises(RefreshAuthError):
+            worker._raise_for_retryable_git_error(process_result, "Auth error")
+
+    def test_raise_for_transient_error_raises_refresh_error(self, worker):
+        """Transient failures raise RefreshError (not the auth subclass)."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = "Connection timed out"
+        with pytest.raises(RefreshError) as exc:
+            worker._raise_for_retryable_git_error(process_result, "Net error")
+        assert not isinstance(exc.value, RefreshAuthError)
+
+    def test_raise_for_non_retryable_returns_none(self, worker):
+        """Non-retryable failures (e.g. divergence) do not raise."""
+        process_result = Mock()
+        process_result.stdout = ""
+        process_result.stderr = "hint: Diverging branches can't be fast-forwarded"
+        assert worker._raise_for_retryable_git_error(process_result, "Diverged") is None
+
+    def test_auth_error_retried_up_to_bounded_budget(self):
+        """Auth errors retry at most _MAX_AUTH_RETRY_ATTEMPTS times."""
+        # Network budget of 5, but auth failures are capped at 2 attempts.
+        worker = RefreshWorker(
+            retry_policy=RetryPolicy(max_attempts=5, base_delay=0.01),
+            ssh_jitter_seconds=0,
+        )
+        result = self._make_result()
+        with (
+            patch.object(
+                worker,
+                "_perform_refresh",
+                side_effect=RefreshAuthError("Authentication error during pull"),
+            ) as mock_refresh,
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            ok = worker._execute_adaptive_refresh(Path("/tmp/repo"), result)
+
+        assert ok is False
+        assert mock_refresh.call_count == 2  # capped, not 5
+        assert mock_sleep.call_count == 1  # one backoff between the two tries
+        assert result.retry_count == 2
+
+    def test_transient_error_uses_full_network_budget(self):
+        """Transient (non-auth) errors use the full max_attempts budget."""
+        worker = RefreshWorker(
+            retry_policy=RetryPolicy(max_attempts=3, base_delay=0.01),
+            ssh_jitter_seconds=0,
+        )
+        result = self._make_result()
+        with (
+            patch.object(
+                worker,
+                "_perform_refresh",
+                side_effect=RefreshError("Network error during pull"),
+            ) as mock_refresh,
+            patch("gerrit_clone.refresh_worker.time.sleep") as mock_sleep,
+        ):
+            ok = worker._execute_adaptive_refresh(Path("/tmp/repo"), result)
+
+        assert ok is False
+        assert mock_refresh.call_count == 3
+        assert mock_sleep.call_count == 2
 
 
 class TestPopStashSubmoduleNoise:

--- a/tests/test_refresh_worker.py
+++ b/tests/test_refresh_worker.py
@@ -617,6 +617,82 @@ class TestRefreshWorker:
 
         assert success is False
         assert result.status == RefreshStatus.CONFLICTS
+        # Conflicts are a hard failure: the message must be recorded.
+        assert result.error_message is not None
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_execute_git_fetch_retryable_error_no_stale_message(
+        self, mock_run, worker, temp_git_repo
+    ):
+        """Retryable fetch failures raise without recording error_message.
+
+        The same RefreshResult is reused across retry attempts, so a
+        message recorded on a transient failure would linger on a later
+        successful attempt. It must only be set for hard failures.
+        """
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "fatal: Could not read from remote repository."
+        mock_run.return_value = mock_result
+
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+
+        with pytest.raises(RefreshError):
+            worker._execute_git_fetch(temp_git_repo, result)
+
+        assert result.error_message is None
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_execute_git_fetch_hard_error_records_message(
+        self, mock_run, worker, temp_git_repo
+    ):
+        """Non-retryable fetch failures record error_message and return False."""
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "fatal: unexpected corruption in object store"
+        mock_run.return_value = mock_result
+
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+
+        success = worker._execute_git_fetch(temp_git_repo, result)
+
+        assert success is False
+        assert result.error_message is not None
+
+    @patch("gerrit_clone.refresh_worker.subprocess.run")
+    def test_execute_git_pull_retryable_error_no_stale_message(
+        self, mock_run, worker, temp_git_repo
+    ):
+        """Retryable pull failures raise without recording error_message."""
+        mock_result = Mock()
+        mock_result.returncode = 1
+        mock_result.stdout = ""
+        mock_result.stderr = "fetch-pack: Connection reset by peer"
+        mock_run.return_value = mock_result
+
+        result = RefreshResult(
+            path=temp_git_repo,
+            project_name="test-repo",
+            status=RefreshStatus.PENDING,
+            started_at=datetime.now(UTC),
+        )
+
+        with pytest.raises(RefreshError):
+            worker._execute_git_pull(temp_git_repo, result)
+
+        assert result.error_message is None
 
 
 class TestRefreshWorkerIntegration:


### PR DESCRIPTION
## Summary

Intermittent `Authentication error during pull` failures when refreshing the
ONAP estate turned out to be **transient Gerrit SSH throttling, not real auth
failures**: under concurrent load Gerrit drops the connection during
authentication and git reports `Permission denied (publickey)`. Each "failed"
repo pulls fine when retried individually, and the failing set varies run to
run.

An audit of the refresh retry/backoff/concurrency machinery found three
weaknesses, fixed here.

## Changes

1. **Bounded retry for throttle-induced auth rejections.** A new
   `RefreshAuthError` gives auth-classified failures a *small, dedicated* retry
   budget (`_MAX_AUTH_RETRY_ATTEMPTS = 2`) so a throttle blip recovers, while a
   genuine auth misconfiguration still fails fast and never consumes the full
   network-retry budget across every repository. Previously these failed on the
   first attempt with zero backoff.

2. **Full jitter in the refresh backoff.** The backoff used narrow +/-20%
   jitter, so a burst of workers that failed together re-collided on the next
   attempt and re-triggered throttling. Switched to full jitter
   (`uniform(0, delay)`), matching the central `retry.py`.

3. **Absolute Gerrit concurrency ceiling.** The auto thread default was
   CPU-derived (halved but uncapped), reaching 16 on a 32-core host. Capped at
   `_MAX_GERRIT_THREADS = 8` because the binding constraint is the server's
   per-user SSH connection limit, not local cores. GitHub concurrency is
   unchanged; `--threads` still overrides.

Classified refresh errors (`RefreshError` / `RefreshTimeoutError` /
`RefreshAuthError`) now propagate unchanged through `_perform_refresh` so the
retry loop applies the correct budget instead of re-wrapping them generically.

## Tests

Added coverage for auth classification (`_is_auth_git_error`), the shared
`_raise_for_retryable_git_error` dispatcher, bounded-vs-full retry budgets in
`_execute_adaptive_refresh`, the new full-jitter bounds, and the Gerrit thread
cap. Full suite: **1102 passed**; `ruff`, `mypy`, and the full pre-commit hook
set are green.

## Notes / follow-up

- Auth is now retried a *bounded* 2 attempts rather than being strictly
  non-retryable - a deliberate tradeoff to recover throttle blips (confirmed
  root cause). Genuine auth failure still fails quickly.
- Out of scope (flagged for a future PR): the codebase has **three separate
  retry implementations** (`retry.py`,
  `git_comparison._run_git_command_with_retry`, and the refresh worker's
  bespoke loop). Consolidating them behind one classifier would reduce drift
  but is higher risk than warranted here.
