### PR TITLE
Chore: Ignore PLR0917 too-many-positional-args

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,10 +192,31 @@ select = [
 ignore = [
     "E501",   # line too long, handled by formatter
     "PLR0913", # too many arguments
+    "PLR0917", # too many positional arguments — see note below
     "PLR0912", # too many branches
     "PLR0915", # too many statements — CLI commands and managers are complex by design
     "PLR2004", # magic value used in comparison
 ]
+
+# PLR0917 was stabilised in ruff 0.16.0.  This project already selects
+# the "PL" category, so a routine pre-commit autoupdate crossing that
+# release began failing on code nobody had touched.
+#
+# It is ignored globally rather than only under tests because both
+# call sites are legitimate:
+#
+#   - tests/ stack @patch decorators, and unittest.mock injects each
+#     mock positionally, so a keyword-only signature is impossible
+#     rather than merely inconvenient.
+#   - src/gerrit_clone/refresh_worker.py declares RefreshWorker.__init__
+#     with eleven defaulted parameters.  The closely related PLR0913
+#     (too many arguments) is already ignored directly above for exactly
+#     that constructor.  PLR0917 counts only those arguments that may be
+#     passed positionally, so it is the narrower of the two; ignoring one
+#     while enforcing the other would be inconsistent.
+#
+# Scoping it to tests alone would leave src/ latently failing the moment
+# the ruff hook's `files:` pattern is corrected to include src/.
 
 [tool.ruff.lint.per-file-ignores]
 "tests/**/*" = ["ARG", "S101", "PLR2004"]


### PR DESCRIPTION
## Why

Unlike its sibling repos in this sweep, this repository **already pins a comprehensive ruff rule set** — including the `PL` (pylint) category. So the problem here is not an unpinned `select`; it is that ruff 0.16.0 **stabilised `PLR0917`** (too many positional arguments), and `PL` picks it up automatically.

The rule began firing the moment the `pre-commit` autoupdate crossed that version boundary, on code nobody had touched. That is what fails the open autoupdate PR #233 here, on six test functions:

```
tests/test_cli_netrc_options.py:284  PLR0917 Too many positional arguments (6 > 5)
tests/test_refresh_worker.py:939     PLR0917 (6 > 5)
tests/test_refresh_worker.py:983     PLR0917 (6 > 5)
tests/test_refresh_worker.py:1018    PLR0917 (6 > 5)
tests/test_refresh_worker.py:1052    PLR0917 (6 > 5)
tests/test_refresh_worker.py:1094    PLR0917 (6 > 5)
```

This is the same rule and the same root cause as `repository-metadata-action#148`.

## Why a global ignore, not a test-only one

`repository-metadata-action#148` scoped its ignore to `per-file-ignores` for tests. Here that would be insufficient, because **both** call sites are legitimate:

- **`tests/`** stack `@patch` decorators. `unittest.mock` injects each mock **positionally**, so a keyword-only signature is impossible rather than merely inconvenient:

  ```python
  @patch("gerrit_clone.refresh_worker.RefreshWorker._is_meta_only_repo")
  @patch("gerrit_clone.refresh_worker.RefreshWorker._get_default_branch")
  @patch("gerrit_clone.refresh_worker.RefreshWorker._is_on_meta_config")
  @patch("gerrit_clone.refresh_worker.subprocess.run")
  def test_fix_detached_head_success(
      self, mock_run, mock_meta_config, mock_default_branch, mock_meta_only, worker,
  ):
  ```

- **`src/gerrit_clone/refresh_worker.py:127`** declares `RefreshWorker.__init__` with eleven defaulted parameters. Its sibling rule **`PLR0913` (too many arguments) is already ignored globally, directly above**, for exactly that constructor. Ignoring the positional-only counterpart keeps the two consistent.

Scoping to tests alone would leave `src/` **latently failing** the moment the ruff hook's `files:` pattern is corrected to include `src/` — which is queued as a separate org-wide change (see `actions-template#216`, which notes this repo has 33 `src/` files currently unlinted, plus 7 `per-file-ignores` for paths the hook can never reach).

The new ignore sits immediately beside `PLR0913` with a comment recording this reasoning.

## Validation

Verified under **both** ruff 0.15.22 (currently pinned) and 0.16.0 (what the autoupdate moves to):

- Hook-scoped (`scripts tests`) → **All checks passed!** under both versions
- `pre-commit run --all-files` → every hook passes, including the full `pytest` suite

Across the whole tree this takes the count from **19 findings to 1**. The remainder is a pre-existing `PLR0911` (too many return statements) in `src/gerrit_clone/content_filter.py:409`. It predates the bump, is reported **identically by both ruff versions**, and sits outside the paths the hook currently lints — so I have deliberately left it alone rather than smuggling an unrelated fix into a configuration chore. Worth a follow-up before the `files:` pattern is widened.

Unblocks #233.
